### PR TITLE
Timestamp rewrite

### DIFF
--- a/src/animation.ts
+++ b/src/animation.ts
@@ -9,7 +9,7 @@ import {
   snapshot,
   Now,
   sample
-} from "./";
+} from ".";
 
 export type TimingFunction = (t: number) => number;
 

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -560,6 +560,7 @@ class ActiveScanBehavior<A, B> extends ActiveBehavior<B>
       this.pushToChildren(t);
     }
   }
+  pull(t: number) {}
   update(t: number): B {
     throw new Error("Update should never be called.");
   }

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -329,7 +329,7 @@ class ChainBehavior<A, B> extends Behavior<B> {
   }
   update(t: number) {
     const outerChanged = this.outer.changedAt > this.changedAt;
-    if (outerChanged) {
+    if (outerChanged || this.changedAt === undefined) {
       if (this.innerB !== undefined) {
         this.innerB.removeListener(this.innerNode);
       }
@@ -428,6 +428,7 @@ export class ConstantBehavior<A> extends ActiveBehavior<A> {
   constructor(public last: A) {
     super();
     this.state = State.Push;
+    this.changedAt = tick();
   }
   update(_t: number) {
     return this.last;

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -686,7 +686,7 @@ class MomentBehavior<A> extends Behavior<A> {
     const node = new Node(this);
     this.listenerNodes = cons({ node, parent: b }, this.listenerNodes);
     b.addListener(node);
-
+    b.pull(tick());
     this.parents = cons(b, this.parents);
     return b.last;
   }

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -12,7 +12,7 @@ import {
 import { Future, BehaviorFuture } from "./future";
 import * as F from "./future";
 import { Stream } from "./stream";
-import { tick } from "./timestamp";
+import { tick } from "./clock";
 
 /**
  * A behavior is a value that changes over time. Conceptually it can
@@ -27,9 +27,9 @@ export abstract class Behavior<A> extends Reactive<A, BListener>
   // Behaviors cache their last value in `last`.
   last: A;
   children: DoubleLinkedList<BListener> = new DoubleLinkedList();
-  // listening for updates
   nrOfListeners: number;
   // Amount of nodes that wants to pull the behavior without actively
+  // listening for updates
   nrOfPullers: number;
   pulledAt: number | undefined;
   changedAt: number | undefined;

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -466,50 +466,40 @@ class SwitcherBehavior<A> extends ActiveBehavior<A>
     next: Future<Behavior<A>> | Stream<Behavior<A>>
   ) {
     super();
+    this.parents = cons(b);
     b.addListener(this.bNode);
     this.state = b.state;
     if (this.state === State.Push) {
       this.last = at(b);
     }
-    // FIXME: Using `bind` is hardly optimal for performance.
-    //next.subscribe(this.doSwitch.bind(this));
     // @ts-ignore
     next.addListener(this.nNode);
   }
   update(t: number): A {
-    throw new Error("Method not implemented.");
-  }
-  push(t: number): void {
-    if (this.last !== this.b.last) {
-      this.last = this.b.last;
-      this.pushToChildren(t);
-    }
+    return this.b.last;
   }
   pushS(t: number, value: Behavior<A>): void {
     this.doSwitch(t, value);
   }
   pushF(t: number, value: Behavior<A>): void {
-    this.doSwitch(t, value); // FIXME: should use a timestamp other than 0
+    this.doSwitch(t, value);
   }
   changeStateDown(state: State): void {
     for (const child of this.children) {
       child.changeStateDown(state);
     }
   }
-
   private doSwitch(t: number, newB: Behavior<A>): void {
     this.b.removeListener(this.bNode);
     this.b = newB;
+    this.parents = cons(newB);
     newB.addListener(this.bNode);
     const newState = newB.state;
-    if (newState === State.Push) {
-      this.last = newB.last;
-      this.push(t);
-    }
     if (newState !== this.state) {
       this.state = newState;
       this.changeStateDown(this.state);
     }
+    this.push(t);
   }
 }
 

--- a/src/clock.ts
+++ b/src/clock.ts
@@ -1,0 +1,5 @@
+let time = -1;
+
+export function tick() {
+  return ++time;
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -119,6 +119,7 @@ export abstract class Reactive<A, C extends Child> implements Child {
     }
   }
   changeStateDown(state: State): void {
+    this.state = state;
     for (const child of this.children) {
       child.changeStateDown(state);
     }

--- a/src/common.ts
+++ b/src/common.ts
@@ -75,7 +75,7 @@ export function changePullersParents(
   changePullersParents(n, parents.tail);
 }
 
-type NodeParentPair = {
+export type NodeParentPair = {
   parent: Parent<any>;
   node: Node<any>;
 };
@@ -83,7 +83,6 @@ type NodeParentPair = {
 export abstract class Reactive<A, C extends Child> implements Child {
   nrOfListeners: number;
   state: State;
-  //children: DoubleLinkedList<Observer<A>> = new DoubleLinkedList();
   parents: Cons<Parent<any>>;
   listenerNodes: Cons<NodeParentPair> | undefined;
   children: DoubleLinkedList<C> = new DoubleLinkedList();

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,5 @@
 import { Cons, cons, DoubleLinkedList, Node } from "./datastructures";
 import { Behavior } from "./behavior";
-import { time } from ".";
 import { tick } from "./timestamp";
 
 export type Time = number;
@@ -36,19 +35,14 @@ export interface Child {
 }
 
 export interface BListener extends Child {
-  push(t: number): void;
+  pushB(t: number): void;
 }
 
 export interface SListener<A> extends Child {
   pushS(t: number, value: A): void;
 }
 
-export interface FListener<A> extends Child {
-  pushF(t: number, value: A): void;
-}
-
-export class PushOnlyObserver<A>
-  implements BListener, SListener<A>, FListener<A> {
+export class PushOnlyObserver<A> implements BListener, SListener<A> {
   node = new Node(this);
   constructor(private callback: (a: A) => void, private source: Parent<Child>) {
     source.addListener(this.node);
@@ -56,13 +50,10 @@ export class PushOnlyObserver<A>
       callback(source.at());
     }
   }
-  pushS(t: number, value: A): void {
-    this.callback(value);
-  }
-  push(t: number): void {
+  pushB(t: number): void {
     this.callback((this.source as any).last);
   }
-  pushF(t: number, value: A) {
+  pushS(t: number, value: A) {
     this.callback(value);
   }
   deactivate(): void {
@@ -176,13 +167,10 @@ export class CbObserver<A> implements BListener, SListener<A> {
       this.callback(this.source.last);
     }
   }
-  push(t: number): void {
+  pushB(t: number): void {
     this.callback((this.source as any).last);
   }
   pushS(t: number, value: A): void {
-    this.callback(value);
-  }
-  pushF(t: number, value: A): void {
     this.callback(value);
   }
   changeStateDown(state: State): void {

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,6 @@
 import { Cons, cons, DoubleLinkedList, Node } from "./datastructures";
 import { Behavior } from "./behavior";
-import { tick } from "./timestamp";
+import { tick } from "./clock";
 
 export type Time = number;
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -16,7 +16,7 @@ class DomEventStream<A> extends ProducerStream<A> {
     super();
   }
   handleEvent(event: Event): void {
-    this.push(this.extractor(event, this.target));
+    this.pushS(undefined, this.extractor(event, this.target));
   }
   activate(): void {
     this.target.addEventListener(this.eventName, this);
@@ -79,7 +79,7 @@ class DomEventBehavior<A> extends ProducerBehavior<A> {
     this.last = initial;
   }
   handleEvent(event: Event): void {
-    this.push(this.extractor(event, this.target));
+    this.newValue(this.extractor(event, this.target));
   }
   activateProducer(): void {
     this.target.addEventListener(this.eventName, this);

--- a/src/future.ts
+++ b/src/future.ts
@@ -1,12 +1,9 @@
 import { monad, Monad, Semigroup } from "@funkia/jabz";
-import { State } from "./common";
-import { Observer, Reactive } from "./common";
-import { cons, fromArray, Node } from "./datastructures";
+import { State, FListener, Parent, BListener } from "./common";
+import { Reactive } from "./common";
+import { cons, fromArray, Node, DoubleLinkedList } from "./datastructures";
 import { Behavior } from "./behavior";
-
-export interface Consumer<A> {
-  push(a: A): void;
-}
+import { tick } from "./timestamp";
 
 /**
  * A future is a thing that occurs at some point in time with a value.
@@ -15,25 +12,30 @@ export interface Consumer<A> {
  * promise.
  */
 @monad
-export abstract class Future<A> extends Reactive<A>
-  implements Semigroup<Future<A>>, Monad<A> {
+export abstract class Future<A> extends Reactive<A, FListener<A>>
+  implements Semigroup<Future<A>>, Monad<A>, Parent<FListener<any>> {
   // The value of the future. Often `undefined` until occurrence.
   value: A;
   constructor() {
     super();
   }
-  abstract push(val: any): void;
+  abstract pushF(t: number, val: any): void;
   pull(): A {
     throw new Error("Pull not implemented on future");
   }
-  resolve(val: A): void {
+  resolve(val: A, t = tick()): void {
     this.deactivate(true);
     this.value = val;
-    this.pushToChildren(val);
+    this.pushFToChildren(t, val);
   }
-  addListener(node: Node<Observer<A>>): State {
+  pushFToChildren(t: number, val: A) {
+    for (const child of this.children) {
+      child.pushF(t, val);
+    }
+  }
+  addListener(node: Node<FListener<A>>): State {
     if (this.state === State.Done) {
-      node.value.push(this.value);
+      node.value.pushF(0, this.value);
       return State.Done;
     } else {
       return super.addListener(node);
@@ -90,7 +92,7 @@ class CombineFuture<A> extends Future<A> {
     super();
     this.parents = cons(future1, cons(future2));
   }
-  push(val: A): void {
+  pushF(t: number, val: A): void {
     this.resolve(val);
   }
 }
@@ -100,8 +102,8 @@ class MapFuture<A, B> extends Future<B> {
     super();
     this.parents = cons(parent);
   }
-  push(val: any): void {
-    this.resolve(this.f(val));
+  pushF(t: number, val: A): void {
+    this.resolve(this.f(val), t);
   }
 }
 
@@ -110,8 +112,8 @@ class MapToFuture<A> extends Future<A> {
     super();
     this.parents = cons(parent);
   }
-  push(_: any): void {
-    this.resolve(this.value);
+  pushF(t: any, _val: any): void {
+    this.resolve(this.value, t);
   }
 }
 
@@ -121,7 +123,7 @@ class OfFuture<A> extends Future<A> {
     this.state = State.Done;
   }
   /* istanbul ignore next */
-  push(_: any): void {
+  pushF(_: any): void {
     throw new Error("A PureFuture should never be pushed to.");
   }
 }
@@ -133,25 +135,25 @@ class LiftFuture<A> extends Future<A> {
     this.missing = futures.length;
     this.parents = fromArray(futures);
   }
-  push(_: any): void {
+  pushF(t: number, _val: any): void {
     if (--this.missing === 0) {
       // All the dependencies have occurred.
       for (let i = 0; i < this.futures.length; ++i) {
         this.futures[i] = this.futures[i].value;
       }
-      this.resolve(this.f.apply(undefined, this.futures));
+      this.resolve(this.f.apply(undefined, this.futures), t);
     }
   }
 }
 
-class ChainFuture<A, B> extends Future<B> {
+class ChainFuture<A, B> extends Future<B> implements FListener<A> {
   private parentOccurred: boolean = false;
   private node = new Node(this);
   constructor(private f: (a: A) => Future<B>, private parent: Future<A>) {
     super();
     this.parents = cons(parent);
   }
-  push(val: any): void {
+  pushF(t: number, val: any): void {
     if (this.parentOccurred === false) {
       // The first future occurred. We can now call `f` with its value
       // and listen to the future it returns.
@@ -159,7 +161,7 @@ class ChainFuture<A, B> extends Future<B> {
       const newFuture = this.f(val);
       newFuture.addListener(this.node);
     } else {
-      this.resolve(val);
+      this.resolve(val, t);
     }
   }
 }
@@ -170,7 +172,7 @@ class ChainFuture<A, B> extends Future<B> {
  */
 export class SinkFuture<A> extends Future<A> {
   /* istanbul ignore next */
-  push(val: any): void {
+  pushF(t: number, val: any): void {
     throw new Error("A sink should not be pushed to.");
   }
   activate(): void {}
@@ -193,18 +195,18 @@ export function fromPromise<A>(p: Promise<A>): Future<A> {
  * impure and should not be done directly.
  * @private
  */
-export class BehaviorFuture<A> extends SinkFuture<A> implements Observer<A> {
+export class BehaviorFuture<A> extends SinkFuture<A> implements BListener {
   node = new Node(this);
   constructor(private b: Behavior<A>) {
     super();
     b.addListener(this.node);
   }
   /* istanbul ignore next */
-  changeStateDown(): void {
-    throw new Error("Behavior future does not support pushing behavior");
+  changeStateDown(state: State): void {
+    throw new Error("Behavior future does not support pulling behavior");
   }
-  push(a: A): void {
+  push(t: number): void {
     this.b.removeListener(this.node);
-    this.resolve(a);
+    this.resolve(this.b.last, t);
   }
 }

--- a/src/future.ts
+++ b/src/future.ts
@@ -3,7 +3,7 @@ import { State, SListener, Parent, BListener } from "./common";
 import { Reactive } from "./common";
 import { cons, fromArray, Node } from "./datastructures";
 import { Behavior } from "./behavior";
-import { tick } from "./timestamp";
+import { tick } from "./clock";
 
 /**
  * A future is a thing that occurs at some point in time with a value.

--- a/src/future.ts
+++ b/src/future.ts
@@ -33,12 +33,12 @@ export abstract class Future<A> extends Reactive<A, SListener<A>>
       child.pushS(t, val);
     }
   }
-  addListener(node: Node<SListener<A>>): State {
+  addListener(node: Node<SListener<A>>, t: number): State {
     if (this.state === State.Done) {
-      node.value.pushS(0, this.value);
+      node.value.pushS(t, this.value);
       return State.Done;
     } else {
-      return super.addListener(node);
+      return super.addListener(node, t);
     }
   }
   combine(future: Future<A>): Future<A> {
@@ -159,7 +159,7 @@ class ChainFuture<A, B> extends Future<B> implements SListener<A> {
       // and listen to the future it returns.
       this.parentOccurred = true;
       const newFuture = this.f(val);
-      newFuture.addListener(this.node);
+      newFuture.addListener(this.node, t);
     } else {
       this.resolve(val, t);
     }
@@ -199,7 +199,7 @@ export class BehaviorFuture<A> extends SinkFuture<A> implements BListener {
   node = new Node(this);
   constructor(private b: Behavior<A>) {
     super();
-    b.addListener(this.node);
+    b.addListener(this.node, tick());
   }
   /* istanbul ignore next */
   changeStateDown(state: State): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,14 @@ import { Behavior, SinkBehavior } from "./behavior";
 
 export * from "./common";
 export * from "./behavior";
-// export * from "./stream";
-// export * from "./future";
-// export * from "./now";
-// export * from "./dom";
+export * from "./stream";
+export * from "./future";
+export * from "./now";
+export * from "./dom";
 export * from "./time";
-// export * from "./placeholder";
-// export * from "./animation";
-// export * from "./test";
+export * from "./placeholder";
+export * from "./animation";
+export * from "./test";
 
 /**
  * Map a function over a behavior or stream. This means that if at some point in
@@ -23,6 +23,6 @@ export function map<A, B>(fn: (a: A) => B, b: any): any {
   return b.map(fn);
 }
 
-export function publish<A>(a: A, sink: SinkBehavior<A>): void {
+export function publish<A>(a: A, sink: SinkBehavior<A> | SinkStream<A>): void {
   sink.publish(a);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,5 +24,5 @@ export function map<A, B>(fn: (a: A) => B, b: any): any {
 }
 
 export function publish<A>(a: A, sink: SinkBehavior<A> | SinkStream<A>): void {
-  sink.publish(a);
+  sink.push(a);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,6 @@ export function map<A, B>(fn: (a: A) => B, b: any): any {
   return b.map(fn);
 }
 
-export function publish<A>(a: A, sink: SinkBehavior<A> | SinkStream<A>): void {
+export function push<A>(a: A, sink: SinkBehavior<A> | SinkStream<A>): void {
   sink.push(a);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,14 @@ import { Behavior, SinkBehavior } from "./behavior";
 
 export * from "./common";
 export * from "./behavior";
-export * from "./stream";
-export * from "./future";
-export * from "./now";
-export * from "./dom";
+// export * from "./stream";
+// export * from "./future";
+// export * from "./now";
+// export * from "./dom";
 export * from "./time";
-export * from "./placeholder";
-export * from "./animation";
-export * from "./test";
+// export * from "./placeholder";
+// export * from "./animation";
+// export * from "./test";
 
 /**
  * Map a function over a behavior or stream. This means that if at some point in
@@ -23,9 +23,6 @@ export function map<A, B>(fn: (a: A) => B, b: any): any {
   return b.map(fn);
 }
 
-export function publish<A>(
-  a: A,
-  stream: SinkStream<A> | SinkBehavior<A>
-): void {
-  stream.push(a);
+export function publish<A>(a: A, sink: SinkBehavior<A>): void {
+  sink.publish(a);
 }

--- a/src/now.ts
+++ b/src/now.ts
@@ -5,7 +5,7 @@ import { Future, fromPromise, sinkFuture } from "./future";
 import { Node } from "./datastructures";
 import { Behavior, at } from "./behavior";
 import { ActiveStream, Stream } from "./stream";
-import { tick } from "./timestamp";
+import { tick } from "./clock";
 
 @monad
 export abstract class Now<A> implements Monad<A> {

--- a/src/now.ts
+++ b/src/now.ts
@@ -97,7 +97,7 @@ class PerformIOStream<A> extends ActiveStream<A> implements SListener<IO<A>> {
   node = new Node(this);
   constructor(s: Stream<IO<A>>) {
     super();
-    s.addListener(this.node);
+    s.addListener(this.node, tick());
     this.state = State.Push;
   }
   pushS(_t: number, io: IO<A>): void {
@@ -126,7 +126,7 @@ class PerformIOStreamLatest<A> extends ActiveStream<A>
   private node = new Node(this);
   constructor(s: Stream<IO<A>>) {
     super();
-    s.addListener(this.node);
+    s.addListener(this.node, tick());
   }
   next: number = 0;
   newest: number = 0;
@@ -167,7 +167,7 @@ class PerformIOStreamOrdered<A> extends ActiveStream<A> {
   private node = new Node(this);
   constructor(s: Stream<IO<A>>) {
     super();
-    s.addListener(this.node);
+    s.addListener(this.node, tick());
   }
   nextId: number = 0;
   next: number = 0;

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -1,10 +1,5 @@
-import { Reactive, State, FListener, BListener, SListener } from "./common";
-import {
-  Behavior,
-  ConstantBehavior,
-  isBehavior,
-  MapBehavior
-} from "./behavior";
+import { Reactive, State, SListener, BListener } from "./common";
+import { Behavior, isBehavior, MapBehavior } from "./behavior";
 import { Node } from "./datastructures";
 import { Stream, MapToStream } from "./stream";
 import { tick } from "./timestamp";
@@ -18,37 +13,32 @@ class SamplePlaceholderError {
 }
 
 export class Placeholder<A> extends Behavior<A> {
-  source: Reactive<A, SListener<A> | FListener<A> | BListener>;
+  source: Reactive<A, SListener<A> | SListener<A> | BListener>;
   private node = new Node(this);
   replaceWith(
-    parent: Reactive<A, SListener<A> | FListener<A> | BListener>
+    parent: Reactive<A, SListener<A> | SListener<A> | BListener>
   ): void {
     this.source = parent;
     if (this.children.head !== undefined) {
       this.activate();
       if (isBehavior(parent) && this.state === State.Push) {
         const t = tick();
-        this.push(t);
+        this.pushB(t);
       }
     }
     if (isBehavior(parent)) {
       parent.changePullers(this.nrOfPullers);
     }
   }
-  push(t: number): void {
+  pushB(t: number): void {
     this.last = (<Behavior<A>>this.source).last;
     for (const child of this.children) {
-      child.push(t);
+      child.pushB(t);
     }
   }
   pushS(t: number, a: A) {
     for (const child of this.children) {
       (<any>child).pushS(t, a);
-    }
-  }
-  pushF(t: number, a: A) {
-    for (const child of this.children) {
-      (<any>child).pushF(t, a);
     }
   }
   pull(t: number) {

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -20,9 +20,9 @@ export class Placeholder<A> extends Behavior<A> {
   ): void {
     this.source = parent;
     if (this.children.head !== undefined) {
-      this.activate();
+      const t = tick();
+      this.activate(t);
       if (isBehavior(parent) && this.state === State.Push) {
-        const t = tick();
         this.pushB(t);
       }
     }
@@ -54,9 +54,9 @@ export class Placeholder<A> extends Behavior<A> {
   update(t: number): A {
     throw new Error("Update should never be called on a placeholder.");
   }
-  activate(): void {
+  activate(t: number): void {
     if (this.source !== undefined) {
-      this.source.addListener(this.node);
+      this.source.addListener(this.node, t);
       this.state = this.source.state;
       this.changeStateDown(this.state);
     }

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -2,7 +2,7 @@ import { Reactive, State, SListener, BListener } from "./common";
 import { Behavior, isBehavior, MapBehavior } from "./behavior";
 import { Node } from "./datastructures";
 import { Stream, MapToStream } from "./stream";
-import { tick } from "./timestamp";
+import { tick } from "./clock";
 
 class SamplePlaceholderError {
   message: string = "Attempt to sample non-replaced placeholder";

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,7 +1,7 @@
 import { Reactive, State, Time, SListener, Parent, BListener } from "./common";
 import { cons, Node, DoubleLinkedList } from "./datastructures";
 import { Behavior, fromFunction, scan } from "./behavior";
-import { tick } from "./timestamp";
+import { tick } from "./clock";
 
 export type Occurrence<A> = {
   time: Time;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,6 +1,6 @@
 import { Reactive, State, Time, SListener, Parent, BListener } from "./common";
 import { cons, Node, DoubleLinkedList } from "./datastructures";
-import { Behavior, fromFunction } from "./behavior";
+import { Behavior, fromFunction, scan } from "./behavior";
 import { tick } from "./timestamp";
 
 export type Occurrence<A> = {
@@ -37,7 +37,7 @@ export abstract class Stream<A> extends Reactive<A, SListener<A>>
     return fromFunction(() => new ScanStream(fn, startingValue, this));
   }
   scan<B>(fn: (a: A, b: B) => B, init: B): Behavior<Behavior<B>> {
-    return; //scan(fn, init, this);
+    return scan(fn, init, this);
   }
   log(prefix?: string): Stream<A> {
     this.subscribe((a) => console.log(`${prefix || ""} `, a));
@@ -345,12 +345,9 @@ export class SinkStream<A> extends ProducerStream<A> {
       this.pushSToChildren(t, a);
     }
   }
-  publish(a: A): void {
+  push(a: A): void {
     const t = tick();
     this.pushSToChildren(t, a);
-  }
-  push(a: A) {
-    this.publish(a);
   }
   activate(): void {
     this.pushing = true;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,7 +1,6 @@
 import { Reactive, State, Time, SListener, Parent, BListener } from "./common";
 import { cons, Node, DoubleLinkedList } from "./datastructures";
 import { Behavior, fromFunction } from "./behavior";
-// import { DelayStream } from "./time";
 import { tick } from "./timestamp";
 
 export type Occurrence<A> = {
@@ -207,7 +206,7 @@ export function scanS<A, B>(
   return stream.scanS(fn, startingValue);
 }
 
-class SwitchBehaviorStream<A> extends Stream<A> {
+class SwitchBehaviorStream<A> extends Stream<A> implements BListener {
   private bNode = new Node(this);
   private sNode = new Node(this);
   private currentSource: Stream<A>;
@@ -223,7 +222,7 @@ class SwitchBehaviorStream<A> extends Stream<A> {
     this.b.removeListener(this.bNode);
     this.currentSource.removeListener(this.sNode);
   }
-  push(t: number): void {
+  pushB(t: number): void {
     this.doSwitch(this.b.last);
   }
   pushS(t: number, a: A): void {
@@ -254,7 +253,7 @@ class ChangesStream<A> extends Stream<A> implements BListener {
   changeStateDown(state: State): void {
     throw new Error("Method not implemented.");
   }
-  push(t: number): void {
+  pushB(t: number): void {
     this.pushSToChildren(t, this.parent.last);
   }
   pushS(t: number, a: A): void {
@@ -349,6 +348,9 @@ export class SinkStream<A> extends ProducerStream<A> {
   publish(a: A): void {
     const t = tick();
     this.pushSToChildren(t, a);
+  }
+  push(a: A) {
+    this.publish(a);
   }
   activate(): void {
     this.pushing = true;

--- a/src/test.ts
+++ b/src/test.ts
@@ -17,7 +17,7 @@ class TestStream<A> extends Stream<A> {
     throw new Error("You cannot deactivate a TestStream");
   }
   /* istanbul ignore next */
-  push(a: A): void {
+  pushS(t: number, a: A): void {
     throw new Error("You cannot push to a TestStream");
   }
 }

--- a/src/time.ts
+++ b/src/time.ts
@@ -11,80 +11,80 @@ import {
 /*
  * Time related behaviors and functions
  */
-export class DelayStream<A> extends Stream<A> {
-  constructor(parent: Stream<A>, private ms: number) {
-    super();
-    this.parents = cons(parent);
-  }
-  semantic(): SemanticStream<A> {
-    const s = (<Stream<A>>this.parents.value).semantic();
-    return s.map(({ time, value }) => ({ time: time + this.ms, value }));
-  }
-  push(a: A): void {
-    setTimeout(() => {
-      this.pushToChildren(a);
-    }, this.ms);
-  }
-}
+// export class DelayStream<A> extends Stream<A> {
+//   constructor(parent: Stream<A>, private ms: number) {
+//     super();
+//     this.parents = cons(parent);
+//   }
+//   semantic(): SemanticStream<A> {
+//     const s = (<Stream<A>>this.parents.value).semantic();
+//     return s.map(({ time, value }) => ({ time: time + this.ms, value }));
+//   }
+//   push(a: A): void {
+//     setTimeout(() => {
+//       this.pushToChildren(a);
+//     }, this.ms);
+//   }
+// }
 
-export function delay<A>(ms: number, stream: Stream<A>): Stream<A> {
-  return new DelayStream(stream, ms);
-}
+// export function delay<A>(ms: number, stream: Stream<A>): Stream<A> {
+//   return new DelayStream(stream, ms);
+// }
 
-class ThrottleStream<A> extends Stream<A> {
-  constructor(parent: Stream<A>, private ms: number) {
-    super();
-    this.parents = cons(parent);
-  }
-  private isSilenced: boolean = false;
-  push(a: A): void {
-    if (!this.isSilenced) {
-      this.pushToChildren(a);
-      this.isSilenced = true;
-      setTimeout(() => {
-        this.isSilenced = false;
-      }, this.ms);
-    }
-  }
-}
+// class ThrottleStream<A> extends Stream<A> {
+//   constructor(parent: Stream<A>, private ms: number) {
+//     super();
+//     this.parents = cons(parent);
+//   }
+//   private isSilenced: boolean = false;
+//   push(a: A): void {
+//     if (!this.isSilenced) {
+//       this.pushToChildren(a);
+//       this.isSilenced = true;
+//       setTimeout(() => {
+//         this.isSilenced = false;
+//       }, this.ms);
+//     }
+//   }
+// }
 
-export function throttle<A>(ms: number, stream: Stream<A>): Stream<A> {
-  return new ThrottleStream<A>(stream, ms);
-}
+// export function throttle<A>(ms: number, stream: Stream<A>): Stream<A> {
+//   return new ThrottleStream<A>(stream, ms);
+// }
 
-class DebounceStream<A> extends Stream<A> {
-  constructor(parent: Stream<A>, private ms: number) {
-    super();
-    this.parents = cons(parent);
-  }
-  private timer: any = undefined;
-  push(a: A): void {
-    clearTimeout(this.timer);
-    this.timer = setTimeout(() => {
-      this.pushToChildren(a);
-    }, this.ms);
-  }
-}
+// class DebounceStream<A> extends Stream<A> {
+//   constructor(parent: Stream<A>, private ms: number) {
+//     super();
+//     this.parents = cons(parent);
+//   }
+//   private timer: any = undefined;
+//   push(a: A): void {
+//     clearTimeout(this.timer);
+//     this.timer = setTimeout(() => {
+//       this.pushToChildren(a);
+//     }, this.ms);
+//   }
+// }
 
-export function debounce<A>(ms: number, stream: Stream<A>): Stream<A> {
-  return new DebounceStream<A>(stream, ms);
-}
+// export function debounce<A>(ms: number, stream: Stream<A>): Stream<A> {
+//   return new DebounceStream<A>(stream, ms);
+// }
 
-class TimeFromBehavior extends Behavior<Time> {
-  private startTime: Time;
-  constructor() {
-    super();
-    this.startTime = Date.now();
-    this.state = State.Pull;
-  }
-  pull(): Time {
-    return Date.now() - this.startTime;
-  }
-}
+// class TimeFromBehavior extends Behavior<Time> {
+//   private startTime: Time;
+//   constructor() {
+//     super();
+//     this.startTime = Date.now();
+//     this.state = State.Pull;
+//   }
+//   pull(): Time {
+//     return Date.now() - this.startTime;
+//   }
+// }
 
 class TimeBehavior extends FunctionBehavior<Time> {
   constructor() {
-    super(Date.now);
+    super(() => Date.now());
   }
   semantic(): SemanticBehavior<Time> {
     return (time: Time) => time;
@@ -104,9 +104,9 @@ export const time: Behavior<Time> = new TimeBehavior();
  * between the current sample time and the time at which the outer
  * behavior was sampled.
  */
-export const timeFrom: Behavior<Behavior<Time>> = fromFunction(
-  () => new TimeFromBehavior()
-);
+// export const timeFrom: Behavior<Behavior<Time>> = fromFunction(
+//   () => new TimeFromBehavior()
+// );
 
 class IntegrateBehavior extends Behavior<number> {
   private lastPullTime: Time;
@@ -115,14 +115,15 @@ class IntegrateBehavior extends Behavior<number> {
     super();
     this.lastPullTime = Date.now();
     this.state = State.Pull;
-    this.value = 0;
+    this.last = 0;
+    this.parents = cons(parent, cons(time));
   }
-  pull(): Time {
-    const currentPullTime = Date.now();
+  update(t) {
+    const currentPullTime = time.last;
     const deltaSeconds = (currentPullTime - this.lastPullTime) / 1000;
-    this.value += deltaSeconds * this.parent.at();
+    const value = this.last + deltaSeconds * this.parent.last;
     this.lastPullTime = currentPullTime;
-    return this.value;
+    return value;
   }
 }
 

--- a/src/time.ts
+++ b/src/time.ts
@@ -70,17 +70,20 @@ export function debounce<A>(ms: number, stream: Stream<A>): Stream<A> {
   return new DebounceStream<A>(stream, ms);
 }
 
-// class TimeFromBehavior extends Behavior<Time> {
-//   private startTime: Time;
-//   constructor() {
-//     super();
-//     this.startTime = Date.now();
-//     this.state = State.Pull;
-//   }
-//   pull(): Time {
-//     return Date.now() - this.startTime;
-//   }
-// }
+class TimeFromBehavior extends Behavior<Time> {
+  private startTime: Time;
+  constructor() {
+    super();
+    this.startTime = Date.now();
+    this.state = State.Pull;
+  }
+  pull(t: number) {
+    this.last = Date.now() - this.startTime;
+  }
+  update(t: number): Time {
+    throw new Error("TimeFrom should never call update");
+  }
+}
 
 class TimeBehavior extends FunctionBehavior<Time> {
   constructor() {
@@ -104,9 +107,9 @@ export const time: Behavior<Time> = new TimeBehavior();
  * between the current sample time and the time at which the outer
  * behavior was sampled.
  */
-// export const timeFrom: Behavior<Behavior<Time>> = fromFunction(
-//   () => new TimeFromBehavior()
-// );
+export const timeFrom: Behavior<Behavior<Time>> = fromFunction(
+  () => new TimeFromBehavior()
+);
 
 class IntegrateBehavior extends Behavior<number> {
   private lastPullTime: Time;

--- a/src/time.ts
+++ b/src/time.ts
@@ -11,64 +11,64 @@ import {
 /*
  * Time related behaviors and functions
  */
-// export class DelayStream<A> extends Stream<A> {
-//   constructor(parent: Stream<A>, private ms: number) {
-//     super();
-//     this.parents = cons(parent);
-//   }
-//   semantic(): SemanticStream<A> {
-//     const s = (<Stream<A>>this.parents.value).semantic();
-//     return s.map(({ time, value }) => ({ time: time + this.ms, value }));
-//   }
-//   push(a: A): void {
-//     setTimeout(() => {
-//       this.pushToChildren(a);
-//     }, this.ms);
-//   }
-// }
+export class DelayStream<A> extends Stream<A> {
+  constructor(parent: Stream<A>, private ms: number) {
+    super();
+    this.parents = cons(parent);
+  }
+  semantic(): SemanticStream<A> {
+    const s = (<Stream<A>>this.parents.value).semantic();
+    return s.map(({ time, value }) => ({ time: time + this.ms, value }));
+  }
+  pushS(t: number, a: A): void {
+    setTimeout(() => {
+      this.pushSToChildren(t, a);
+    }, this.ms);
+  }
+}
 
-// export function delay<A>(ms: number, stream: Stream<A>): Stream<A> {
-//   return new DelayStream(stream, ms);
-// }
+export function delay<A>(ms: number, stream: Stream<A>): Stream<A> {
+  return new DelayStream(stream, ms);
+}
 
-// class ThrottleStream<A> extends Stream<A> {
-//   constructor(parent: Stream<A>, private ms: number) {
-//     super();
-//     this.parents = cons(parent);
-//   }
-//   private isSilenced: boolean = false;
-//   push(a: A): void {
-//     if (!this.isSilenced) {
-//       this.pushToChildren(a);
-//       this.isSilenced = true;
-//       setTimeout(() => {
-//         this.isSilenced = false;
-//       }, this.ms);
-//     }
-//   }
-// }
+class ThrottleStream<A> extends Stream<A> {
+  constructor(parent: Stream<A>, private ms: number) {
+    super();
+    this.parents = cons(parent);
+  }
+  private isSilenced: boolean = false;
+  pushS(t: number, a: A): void {
+    if (!this.isSilenced) {
+      this.pushSToChildren(t, a);
+      this.isSilenced = true;
+      setTimeout(() => {
+        this.isSilenced = false;
+      }, this.ms);
+    }
+  }
+}
 
-// export function throttle<A>(ms: number, stream: Stream<A>): Stream<A> {
-//   return new ThrottleStream<A>(stream, ms);
-// }
+export function throttle<A>(ms: number, stream: Stream<A>): Stream<A> {
+  return new ThrottleStream<A>(stream, ms);
+}
 
-// class DebounceStream<A> extends Stream<A> {
-//   constructor(parent: Stream<A>, private ms: number) {
-//     super();
-//     this.parents = cons(parent);
-//   }
-//   private timer: any = undefined;
-//   push(a: A): void {
-//     clearTimeout(this.timer);
-//     this.timer = setTimeout(() => {
-//       this.pushToChildren(a);
-//     }, this.ms);
-//   }
-// }
+class DebounceStream<A> extends Stream<A> {
+  constructor(parent: Stream<A>, private ms: number) {
+    super();
+    this.parents = cons(parent);
+  }
+  private timer: any = undefined;
+  pushS(t: number, a: A): void {
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.pushSToChildren(t, a);
+    }, this.ms);
+  }
+}
 
-// export function debounce<A>(ms: number, stream: Stream<A>): Stream<A> {
-//   return new DebounceStream<A>(stream, ms);
-// }
+export function debounce<A>(ms: number, stream: Stream<A>): Stream<A> {
+  return new DebounceStream<A>(stream, ms);
+}
 
 // class TimeFromBehavior extends Behavior<Time> {
 //   private startTime: Time;

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -1,0 +1,5 @@
+export let timestamp = 1;
+
+export function tick() {
+  return ++timestamp;
+}

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -1,4 +1,4 @@
-export let timestamp = 1;
+let timestamp = 1;
 
 export function tick() {
   return ++timestamp;

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -1,5 +1,0 @@
-let timestamp = 1;
-
-export function tick() {
-  return ++timestamp;
-}

--- a/test/animation.ts
+++ b/test/animation.ts
@@ -19,9 +19,9 @@ describe("animation", () => {
       const t = transitionBehavior(config, 0, target, time).flatten();
       t.subscribe(() => "");
       assert.strictEqual(at(t), 0);
-      time.publish(10);
+      time.push(10);
       assert.strictEqual(at(t), 0);
-      time.publish(20);
+      time.push(20);
       assert.strictEqual(at(t), 0);
     });
     it("should make a simple linear transition", () => {
@@ -37,17 +37,17 @@ describe("animation", () => {
       const tB = transitionBehavior(config, 0, target, time);
       const t = tB.at();
       t.subscribe(() => "");
-      target.publish(10);
+      target.push(10);
       assert.strictEqual(t.at(), 0);
-      time.publish(10);
+      time.push(10);
       assert.strictEqual(t.at(), 1);
-      time.publish(50);
+      time.push(50);
       assert.strictEqual(t.at(), 5);
-      time.publish(90);
+      time.push(90);
       assert.strictEqual(t.at(), 9);
-      time.publish(100);
+      time.push(100);
       assert.strictEqual(t.at(), 10);
-      time.publish(140);
+      time.push(140);
       assert.strictEqual(t.at(), 10);
     });
 
@@ -63,17 +63,17 @@ describe("animation", () => {
 
       const t = transitionBehavior(config, 0, target, time).at();
       t.subscribe(() => "");
-      target.publish(10);
+      target.push(10);
       assert.strictEqual(t.at(), 0);
-      time.publish(90);
+      time.push(90);
       assert.strictEqual(t.at(), 0);
-      time.publish(100);
+      time.push(100);
       assert.strictEqual(t.at(), 0);
-      time.publish(110);
+      time.push(110);
       assert.strictEqual(t.at(), 1);
-      time.publish(190);
+      time.push(190);
       assert.strictEqual(t.at(), 9);
-      time.publish(200);
+      time.push(200);
       assert.strictEqual(t.at(), 10);
     });
   });

--- a/test/animation.ts
+++ b/test/animation.ts
@@ -34,8 +34,7 @@ describe("animation", () => {
         duration: 100
       };
 
-      const tB = transitionBehavior(config, 0, target, time);
-      const t = tB.at();
+      const t = transitionBehavior(config, 0, target, time).at();
       t.subscribe(() => "");
       target.push(10);
       assert.strictEqual(t.at(), 0);
@@ -50,7 +49,29 @@ describe("animation", () => {
       time.push(140);
       assert.strictEqual(t.at(), 10);
     });
-
+    it("should make a simple linear transition", () => {
+      const time = sinkBehavior(0);
+      const target = sinkStream<number>();
+      const config: TransitionConfig = {
+        delay: 0,
+        timingFunction: linear,
+        duration: 100
+      };
+      const t = transitionBehavior(config, 0, target, time).at();
+      t.subscribe(() => "");
+      target.push(10);
+      assert.strictEqual(t.at(), 0);
+      time.push(10);
+      assert.strictEqual(t.at(), 1);
+      time.push(50);
+      assert.strictEqual(t.at(), 5);
+      time.push(90);
+      assert.strictEqual(t.at(), 9);
+      time.push(100);
+      assert.strictEqual(t.at(), 10);
+      time.push(140);
+      assert.strictEqual(t.at(), 10);
+    });
     it("should delay the transition", () => {
       const time = sinkBehavior(0);
       const target = sinkStream<number>();

--- a/test/animation.ts
+++ b/test/animation.ts
@@ -19,9 +19,9 @@ describe("animation", () => {
       const t = transitionBehavior(config, 0, target, time).flatten();
       t.subscribe(() => "");
       assert.strictEqual(at(t), 0);
-      time.push(10);
+      time.publish(10);
       assert.strictEqual(at(t), 0);
-      time.push(20);
+      time.publish(20);
       assert.strictEqual(at(t), 0);
     });
     it("should make a simple linear transition", () => {
@@ -34,45 +34,20 @@ describe("animation", () => {
         duration: 100
       };
 
-      const t = transitionBehavior(config, 0, target, time).at();
+      const tB = transitionBehavior(config, 0, target, time);
+      const t = tB.at();
       t.subscribe(() => "");
-      target.push(10);
+      target.publish(10);
       assert.strictEqual(t.at(), 0);
-      time.push(10);
+      time.publish(10);
       assert.strictEqual(t.at(), 1);
-      time.push(50);
+      time.publish(50);
       assert.strictEqual(t.at(), 5);
-      time.push(90);
+      time.publish(90);
       assert.strictEqual(t.at(), 9);
-      time.push(100);
+      time.publish(100);
       assert.strictEqual(t.at(), 10);
-      time.push(140);
-      assert.strictEqual(t.at(), 10);
-    });
-
-    it("should make a simple linear transition", () => {
-      const time = sinkBehavior(0);
-      const target = sinkStream<number>();
-
-      const config: TransitionConfig = {
-        delay: 0,
-        timingFunction: linear,
-        duration: 100
-      };
-
-      const t = transitionBehavior(config, 0, target, time).at();
-      t.subscribe(() => "");
-      target.push(10);
-      assert.strictEqual(t.at(), 0);
-      time.push(10);
-      assert.strictEqual(t.at(), 1);
-      time.push(50);
-      assert.strictEqual(t.at(), 5);
-      time.push(90);
-      assert.strictEqual(t.at(), 9);
-      time.push(100);
-      assert.strictEqual(t.at(), 10);
-      time.push(140);
+      time.publish(140);
       assert.strictEqual(t.at(), 10);
     });
 
@@ -88,17 +63,17 @@ describe("animation", () => {
 
       const t = transitionBehavior(config, 0, target, time).at();
       t.subscribe(() => "");
-      target.push(10);
+      target.publish(10);
       assert.strictEqual(t.at(), 0);
-      time.push(90);
+      time.publish(90);
       assert.strictEqual(t.at(), 0);
-      time.push(100);
+      time.publish(100);
       assert.strictEqual(t.at(), 0);
-      time.push(110);
+      time.publish(110);
       assert.strictEqual(t.at(), 1);
-      time.push(190);
+      time.publish(190);
       assert.strictEqual(t.at(), 9);
-      time.push(200);
+      time.publish(200);
       assert.strictEqual(t.at(), 10);
     });
   });

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -13,7 +13,10 @@ import {
   sinkBehavior,
   integrate,
   moment,
-  format
+  format,
+  switchTo,
+  fromFunction,
+  sinkFuture
 } from "../src";
 
 import * as H from "../src";
@@ -502,26 +505,26 @@ describe("behavior", () => {
 });
 
 describe("Behavior and Future", () => {
-  describe("when", () => {
-    // it("gives occurred future when behavior is true", () => {
-    //   let occurred = false;
-    //   const b = Behavior.of(true);
-    //   const w = B.when(b);
-    //   const fut = at(w);
-    //   fut.subscribe((_) => (occurred = true));
-    //   assert.strictEqual(occurred, true);
-    // });
-    //     it("future occurs when behavior turns true", () => {
-    //       let occurred = false;
-    //       const b = sinkBehavior(false);
-    //       const w = B.when(b);
-    //       const fut = at(w);
-    //       fut.subscribe((_) => (occurred = true));
-    //       assert.strictEqual(occurred, false);
-    //       b.push(true);
-    //       assert.strictEqual(occurred, true);
-    //     });
-  });
+  // describe("when", () => {
+  // it("gives occurred future when behavior is true", () => {
+  //   let occurred = false;
+  //   const b = Behavior.of(true);
+  //   const w = B.when(b);
+  //   const fut = at(w);
+  //   fut.subscribe((_) => (occurred = true));
+  //   assert.strictEqual(occurred, true);
+  // });
+  //     it("future occurs when behavior turns true", () => {
+  //       let occurred = false;
+  //       const b = sinkBehavior(false);
+  //       const w = B.when(b);
+  //       const fut = at(w);
+  //       fut.subscribe((_) => (occurred = true));
+  //       assert.strictEqual(occurred, false);
+  //       b.push(true);
+  //       assert.strictEqual(occurred, true);
+  //     });
+  // });
   //   describe("snapshotAt", () => {
   //     it("snapshots behavior at future occurring in future", () => {
   //       let result: number;
@@ -546,240 +549,240 @@ describe("Behavior and Future", () => {
   //       assert.strictEqual(result, 2);
   //     });
   //   });
-  //   describe("switchTo", () => {
-  //     it("switches to new behavior", () => {
-  //       const b1 = sinkBehavior(1);
-  //       const b2 = sinkBehavior(8);
-  //       const futureSink = F.sinkFuture<Behavior<number>>();
-  //       const switching = switchTo(b1, futureSink);
-  //       assert.strictEqual(at(switching), 1);
-  //       b2.push(9);
-  //       assert.strictEqual(at(switching), 1);
-  //       b1.push(2);
-  //       assert.strictEqual(at(switching), 2);
-  //       b1.push(3);
-  //       assert.strictEqual(at(switching), 3);
-  //       futureSink.resolve(b2);
-  //       assert.strictEqual(at(switching), 9);
-  //       b2.push(10);
-  //       assert.strictEqual(at(switching), 10);
+  describe("switchTo", () => {
+    it("switches to new behavior", () => {
+      const b1 = sinkBehavior(1);
+      const b2 = sinkBehavior(8);
+      const futureSink = sinkFuture<Behavior<number>>();
+      const switching = switchTo(b1, futureSink);
+      const cb = subscribeSpy(switching);
+      assert.strictEqual(at(switching), 1);
+      b2.publish(9);
+      assert.strictEqual(at(switching), 1);
+      b1.publish(2);
+      b1.publish(3);
+      futureSink.resolve(b2);
+      b2.publish(10);
+      assert.deepEqual(cb.args, [[1], [2], [3], [9], [10]]);
+    });
+    it("changes from push to pull", () => {
+      const pushSpy = spy();
+      const beginPullingSpy = spy();
+      const endPullingSpy = spy();
+      const handlePulling = (...args) => {
+        beginPullingSpy(...args);
+        return endPullingSpy;
+      };
+      const pushingB = sinkBehavior(0);
+      let x = 7;
+      const pullingB = fromFunction(() => x);
+      const futureSink = sinkFuture<Behavior<number>>();
+      const switching = switchTo(pushingB, futureSink);
+      observe(pushSpy, handlePulling, switching);
+      assert.strictEqual(at(switching), 0);
+      pushingB.publish(1);
+      assert.strictEqual(at(switching), 1);
+      futureSink.resolve(pullingB);
+      assert.strictEqual(at(switching), 7);
+      x = 8;
+      assert.strictEqual(at(switching), 8);
+      assert.strictEqual(beginPullingSpy.callCount, 1);
+      assert.strictEqual(endPullingSpy.callCount, 0);
+    });
+    it("changes from pull to push", () => {
+      let beginPull = false;
+      let endPull = false;
+      let pushed: number[] = [];
+      let x = 0;
+      const b1 = fromFunction(() => x);
+      const b2 = sinkBehavior(2);
+      const futureSink = sinkFuture<Behavior<number>>();
+      const switching = switchTo(b1, futureSink);
+      observe(
+        (n: number) => pushed.push(n),
+        () => {
+          beginPull = true;
+          return () => {
+            endPull = true;
+          };
+        },
+        switching
+      );
+      assert.strictEqual(beginPull, true);
+      assert.strictEqual(at(switching), 0);
+      x = 1;
+      assert.strictEqual(at(switching), 1);
+      assert.strictEqual(endPull, false);
+      futureSink.resolve(b2);
+      assert.strictEqual(endPull, true);
+      b2.publish(3);
+      assert.deepEqual(pushed, [2, 3]);
+    });
+  });
+});
+describe("Behavior and Stream", () => {
+  //   describe("switcher", () => {
+  //     it("switches to behavior", () => {
+  //       const result: number[] = [];
+  //       const stream = sinkStream<Behavior<number>>();
+  //       const initB = Behavior.of(1);
+  //       const outerSwitcher = switcher(initB, stream);
+  //       const switchingB = at(outerSwitcher);
+  //       switchingB.subscribe((n) => result.push(n));
+  //       const sinkB = sinkBehavior(2);
+  //       stream.push(sinkB);
+  //       sinkB.push(3);
+  //       assert.deepEqual(result, [1, 2, 3]);
+  //       assert.deepEqual(at(at(outerSwitcher)), 1);
   //     });
-  //     it("changes from push to pull", () => {
-  //       const pushSpy = spy();
-  //       const beginPullingSpy = spy();
-  //       const endPullingSpy = spy();
-  //       const handlePulling = (...args) => {
-  //         beginPullingSpy(...args);
-  //         return endPullingSpy;
-  //       }
-  //       const pushingB = sinkBehavior(0);
-  //       let x = 7;
-  //       const pullingB = fromFunction(() => x);
-  //       const futureSink = F.sinkFuture<Behavior<number>>();
-  //       const switching = switchTo(pushingB, futureSink);
-  //       observe(pushSpy, handlePulling, switching);
-  //       assert.strictEqual(at(switching), 0);
-  //       pushingB.push(1);
-  //       assert.strictEqual(at(switching), 1);
-  //       futureSink.resolve(pullingB);
-  //       assert.strictEqual(at(switching), 7);
-  //       x = 8;
-  //       assert.strictEqual(at(switching), 8);
-  //       assert.strictEqual(beginPullingSpy.callCount, 1);
-  //       assert.strictEqual(endPullingSpy.callCount, 0);
+  //   });
+  describe("stepper", () => {
+    it("steps to the last event value", () => {
+      const s = H.sinkStream();
+      const b = H.stepper(0, s).at();
+      const cb = subscribeSpy(b);
+      s.publish(1);
+      s.publish(2);
+      assert.deepEqual(cb.args, [[0], [1], [2]]);
+    });
+    it("saves last occurrence from stream", () => {
+      const s = H.sinkStream();
+      const t = H.stepper(1, s).at();
+      s.publish(12);
+      const spy = subscribeSpy(t);
+      assert.deepEqual(spy.args, [[12]]);
+    });
+    it("has old value in exact moment", () => {
+      const s = H.sinkStream();
+      const b = H.stepper(0, s).at();
+      const res = H.snapshot(b, s);
+      const spy = subscribeSpy(res);
+      s.publish(1);
+      assert.strictEqual(b.at(), 1);
+      s.publish(2);
+      assert.strictEqual(b.at(), 2);
+      assert.deepEqual(spy.args, [[0], [1]]);
+    });
+  });
+  describe("scan", () => {
+    it("has scan as method on stream", () => {
+      const scanned = H.empty.scan(sum, 0);
+    });
+    it("accumulates in a pure way", () => {
+      const s = H.sinkStream<number>();
+      const scanned = H.scan(sum, 1, s);
+      const b1 = scanned.at();
+      const spy = subscribeSpy(b1);
+      assert.strictEqual(at(b1), 1);
+      s.publish(2);
+      assert.strictEqual(at(b1), 3);
+      const b2 = at(scanned);
+      assert.strictEqual(at(b2), 1);
+      s.publish(4);
+      assert.strictEqual(at(b1), 7);
+      assert.strictEqual(at(b2), 5);
+      assert.deepEqual(spy.args, [[1], [3], [7]]);
+    });
+    it("has semantic representation", () => {
+      const s = H.testStreamFromObject({
+        1: 1,
+        2: 1,
+        4: 2,
+        6: 3,
+        7: 1
+      });
+      const scanned = H.scan((n, m) => n + m, 0, s);
+      const semantic = scanned.semantic();
+      const from0 = semantic(0).semantic();
+      assert.strictEqual(from0(0), 0);
+      assert.strictEqual(from0(1), 1);
+      assert.strictEqual(from0(2), 2);
+      assert.strictEqual(from0(3), 2);
+      assert.strictEqual(from0(4), 4);
+      const from3 = semantic(3).semantic();
+      assert.strictEqual(from3(3), 0);
+      assert.strictEqual(from3(4), 2);
+      assert.strictEqual(from3(5), 2);
+      assert.strictEqual(from3(6), 5);
+      assert.strictEqual(from3(7), 6);
+    });
+  });
+  describe("scanCombine", () => {
+    it("combines several streams", () => {
+      const add = H.sinkStream();
+      const sub = H.sinkStream();
+      const mul = H.sinkStream();
+      const b = H.scanCombine(
+        [
+          [add, (n, m) => n + m],
+          [sub, (n, m) => m - n],
+          [mul, (n, m) => n * m]
+        ],
+        1
+      );
+      const cb = subscribeSpy(b.at());
+      add.publish(3);
+      mul.publish(3);
+      sub.publish(5);
+      assert.deepEqual(cb.args, [[1], [4], [12], [7]]);
+    });
+  });
+  describe("switchStream", () => {
+    it("returns stream that emits from stream", () => {
+      const s1 = H.sinkStream();
+      const s2 = H.sinkStream();
+      const s3 = H.sinkStream();
+      const b = sinkBehavior(s1);
+      const switching = H.switchStream(b);
+      const cb = spy();
+      switching.subscribe(cb);
+      s1.publish(1);
+      s1.publish(2);
+      b.publish(s2);
+      s2.publish(3);
+      b.publish(s3);
+      s2.publish(4);
+      s3.publish(5);
+      s3.publish(6);
+      assert.deepEqual(cb.args, [[1], [2], [3], [5], [6]]);
+    });
+  });
+  //   describe("continuous time", () => {
+  //     it("gives time from sample point", () => {
+  //       const [setTime, restore] = mockNow();
+  //       setTime(3);
+  //       const time = at(timeFrom);
+  //       assert.strictEqual(at(time), 0);
+  //       setTime(4);
+  //       assert.strictEqual(at(time), 1);
+  //       setTime(7);
+  //       assert.strictEqual(at(time), 4);
+  //       restore();
   //     });
-  //     it("changes from pull to push", () => {
+  //     it("gives time since UNIX epoch", () => {
   //       let beginPull = false;
   //       let endPull = false;
   //       let pushed: number[] = [];
-  //       let x = 0;
-  //       const b1 = B.fromFunction(() => x);
-  //       const b2 = sinkBehavior(2);
-  //       const futureSink = F.sinkFuture<Behavior<number>>();
-  //       const switching = switchTo(b1, futureSink);
   //       observe(
   //         (n: number) => pushed.push(n),
   //         () => {
-  //           beginPull = true
-  //           return () => {endPull = true};
+  //           beginPull = true;
+  //           return () => {endPull = true}
   //         },
-  //         switching
+  //         time
   //       );
   //       assert.strictEqual(beginPull, true);
-  //       assert.strictEqual(at(switching), 0);
-  //       x = 1;
-  //       assert.strictEqual(at(switching), 1);
+  //       const t = at(time);
+  //       const now = Date.now();
+  //       assert(now - 2 <= t && t <= now);
   //       assert.strictEqual(endPull, false);
-  //       futureSink.resolve(b2);
-  //       assert.strictEqual(endPull, true);
-  //       b2.push(3);
-  //       assert.deepEqual(pushed, [2, 3]);
   //     });
-  //   });
+  //     it("has semantic representation", () => {
+  //       const f = time.semantic();
+  //       assert.strictEqual(f(0), 0);
+  //       assert.strictEqual(f(1.3), 1.3);
+  //     });
   // });
-  describe("Behavior and Stream", () => {
-    //   describe("switcher", () => {
-    //     it("switches to behavior", () => {
-    //       const result: number[] = [];
-    //       const stream = sinkStream<Behavior<number>>();
-    //       const initB = Behavior.of(1);
-    //       const outerSwitcher = switcher(initB, stream);
-    //       const switchingB = at(outerSwitcher);
-    //       switchingB.subscribe((n) => result.push(n));
-    //       const sinkB = sinkBehavior(2);
-    //       stream.push(sinkB);
-    //       sinkB.push(3);
-    //       assert.deepEqual(result, [1, 2, 3]);
-    //       assert.deepEqual(at(at(outerSwitcher)), 1);
-    //     });
-    //   });
-    describe("stepper", () => {
-      it("steps to the last event value", () => {
-        const s = H.sinkStream();
-        const b = H.stepper(0, s).at();
-        const cb = subscribeSpy(b);
-        s.publish(1);
-        s.publish(2);
-        assert.deepEqual(cb.args, [[0], [1], [2]]);
-      });
-      it("saves last occurrence from stream", () => {
-        const s = H.sinkStream();
-        const t = H.stepper(1, s).at();
-        s.publish(12);
-        const spy = subscribeSpy(t);
-        assert.deepEqual(spy.args, [[12]]);
-      });
-      it("has old value in exact moment", () => {
-        const s = H.sinkStream();
-        const b = H.stepper(0, s).at();
-        const res = H.snapshot(b, s);
-        const spy = subscribeSpy(res);
-        s.publish(1);
-        assert.strictEqual(b.at(), 1);
-        s.publish(2);
-        assert.strictEqual(b.at(), 2);
-        assert.deepEqual(spy.args, [[0], [1]]);
-      });
-    });
-    describe("scan", () => {
-      it("has scan as method on stream", () => {
-        const scanned = H.empty.scan(sum, 0);
-      });
-      it("accumulates in a pure way", () => {
-        const s = H.sinkStream<number>();
-        const scanned = H.scan(sum, 1, s);
-        const b1 = scanned.at();
-        const spy = subscribeSpy(b1);
-        assert.strictEqual(at(b1), 1);
-        s.publish(2);
-        assert.strictEqual(at(b1), 3);
-        const b2 = at(scanned);
-        assert.strictEqual(at(b2), 1);
-        s.publish(4);
-        assert.strictEqual(at(b1), 7);
-        assert.strictEqual(at(b2), 5);
-        assert.deepEqual(spy.args, [[1], [3], [7]]);
-      });
-      it("has semantic representation", () => {
-        const s = H.testStreamFromObject({
-          1: 1,
-          2: 1,
-          4: 2,
-          6: 3,
-          7: 1
-        });
-        const scanned = H.scan((n, m) => n + m, 0, s);
-        const semantic = scanned.semantic();
-        const from0 = semantic(0).semantic();
-        assert.strictEqual(from0(0), 0);
-        assert.strictEqual(from0(1), 1);
-        assert.strictEqual(from0(2), 2);
-        assert.strictEqual(from0(3), 2);
-        assert.strictEqual(from0(4), 4);
-        const from3 = semantic(3).semantic();
-        assert.strictEqual(from3(3), 0);
-        assert.strictEqual(from3(4), 2);
-        assert.strictEqual(from3(5), 2);
-        assert.strictEqual(from3(6), 5);
-        assert.strictEqual(from3(7), 6);
-      });
-    });
-    describe("scanCombine", () => {
-      it("combines several streams", () => {
-        const add = H.sinkStream();
-        const sub = H.sinkStream();
-        const mul = H.sinkStream();
-        const b = H.scanCombine(
-          [
-            [add, (n, m) => n + m],
-            [sub, (n, m) => m - n],
-            [mul, (n, m) => n * m]
-          ],
-          1
-        );
-        const cb = subscribeSpy(b.at());
-        add.publish(3);
-        mul.publish(3);
-        sub.publish(5);
-        assert.deepEqual(cb.args, [[1], [4], [12], [7]]);
-      });
-    });
-    describe("switchStream", () => {
-      it("returns stream that emits from stream", () => {
-        const s1 = H.sinkStream();
-        const s2 = H.sinkStream();
-        const s3 = H.sinkStream();
-        const b = sinkBehavior(s1);
-        const switching = H.switchStream(b);
-        const cb = spy();
-        switching.subscribe(cb);
-        s1.publish(1);
-        s1.publish(2);
-        b.publish(s2);
-        s2.publish(3);
-        b.publish(s3);
-        s2.publish(4);
-        s3.publish(5);
-        s3.publish(6);
-        assert.deepEqual(cb.args, [[1], [2], [3], [5], [6]]);
-      });
-    });
-    //   describe("continuous time", () => {
-    //     it("gives time from sample point", () => {
-    //       const [setTime, restore] = mockNow();
-    //       setTime(3);
-    //       const time = at(timeFrom);
-    //       assert.strictEqual(at(time), 0);
-    //       setTime(4);
-    //       assert.strictEqual(at(time), 1);
-    //       setTime(7);
-    //       assert.strictEqual(at(time), 4);
-    //       restore();
-    //     });
-    //     it("gives time since UNIX epoch", () => {
-    //       let beginPull = false;
-    //       let endPull = false;
-    //       let pushed: number[] = [];
-    //       observe(
-    //         (n: number) => pushed.push(n),
-    //         () => {
-    //           beginPull = true;
-    //           return () => {endPull = true}
-    //         },
-    //         time
-    //       );
-    //       assert.strictEqual(beginPull, true);
-    //       const t = at(time);
-    //       const now = Date.now();
-    //       assert(now - 2 <= t && t <= now);
-    //       assert.strictEqual(endPull, false);
-    //     });
-    //     it("has semantic representation", () => {
-    //       const f = time.semantic();
-    //       assert.strictEqual(f(0), 0);
-    //       assert.strictEqual(f(1.3), 1.3);
-    //     });
-  });
   describe("toggle", () => {
     it("has correct initial value", () => {
       const s1 = H.sinkStream();

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -1,34 +1,34 @@
-import { scanCombine } from "../src/behavior";
 import "mocha";
 import { assert } from "chai";
 import { spy, useFakeTimers } from "sinon";
 import { go, lift, map, mapTo } from "@funkia/jabz";
 import {
-  testBehavior,
   at,
   Behavior,
-  fromFunction,
-  Future,
-  integrate,
   isBehavior,
   observe,
-  placeholder,
   ProducerBehavior,
-  testStreamFromObject,
   producerBehavior,
   publish,
-  scan,
   sinkBehavior,
-  sinkStream,
-  stepper,
-  switcher,
-  switchStream,
-  switchTo,
-  time,
-  timeFrom,
-  toggle,
+  // Future,
+  integrate,
+  // placeholder,
+  // testStreamFromObject,
+  // sinkStream,
+  // switchStream,
+  // time,
+  // timeFrom,
   snapshot,
-  empty,
+  // empty,
+  // scanCombine,
+  // testBehavior
+  //fromFunction,
+  // scan,
+  // stepper,
+  // switcher,
+  // switchTo,
+  // toggle,
   moment,
   format
 } from "../src";
@@ -37,6 +37,7 @@ import * as B from "../src/behavior";
 import * as F from "../src/future";
 
 import { subscribeSpy } from "./helpers";
+import { placeholder } from "../src/placeholder";
 
 function double(n: number): number {
   return n * 2;
@@ -69,7 +70,7 @@ describe("behavior", () => {
       assert.isFalse(isBehavior(1234));
       assert.isFalse(isBehavior(B.isBehavior));
       // A stream is not a behavior
-      assert.isFalse(isBehavior(sinkStream()));
+      //     assert.isFalse(isBehavior(sinkStream()));
       assert.isFalse(Behavior.is(1));
     });
   });
@@ -77,7 +78,7 @@ describe("behavior", () => {
     it("activates and deactivates", () => {
       const activate = spy();
       const deactivate = spy();
-      class MyProducer<A> extends ProducerBehavior<A> {
+      class MyProducer<A> extends B.ProducerBehavior<A> {
         activateProducer(): void {
           activate();
         }
@@ -109,22 +110,26 @@ describe("behavior", () => {
   describe("fromFunction", () => {
     it("pulls from time varying functions", () => {
       let time = 0;
-      const b = fromFunction(() => time);
-      assert.equal(B.at(b), 0);
+      const b = B.fromFunction(() => time);
+      assert.equal(B.at(b, 1), 0);
       time = 1;
-      assert.equal(B.at(b), 1);
+      assert.equal(B.at(b, 2), 1);
       time = 2;
-      assert.equal(B.at(b), 2);
+      assert.equal(B.at(b, 3), 2);
       time = 3;
-      assert.equal(B.at(b), 3);
+      assert.equal(B.at(b, 4), 3);
     });
   });
   describe("functor", () => {
     describe("map", () => {
       it("maps over initial value from parent", () => {
         const b = Behavior.of(3);
+        assert.strictEqual(at(b, 1), 3);
         const mapped = map(double, b);
-        assert.strictEqual(at(mapped), 6);
+
+        let a;
+        mapped.observe((v) => (a = v), () => {});
+        assert.strictEqual(a, 6);
       });
       it("maps constant function", () => {
         const b = sinkBehavior(0);
@@ -132,11 +137,8 @@ describe("behavior", () => {
         const cb = spy();
         mapped.subscribe(cb);
         publish(1, b);
-        assert.strictEqual(mapped.at(), 2);
         publish(2, b);
-        assert.strictEqual(mapped.at(), 4);
         publish(3, b);
-        assert.strictEqual(mapped.at(), 6);
         assert.deepEqual(cb.args, [[0], [2], [4], [6]]);
       });
       it("maps time function", () => {
@@ -145,16 +147,20 @@ describe("behavior", () => {
           return time;
         });
         const mapped = map(double, b);
-        assert.equal(B.at(mapped), 0);
-        time = 1;
-        assert.equal(B.at(mapped), 2);
-        time = 2;
-        assert.equal(B.at(mapped), 4);
-        time = 3;
-        assert.equal(B.at(mapped), 6);
+        const cb = spy();
+        mapped.observe(cb, (pull) => {
+          pull(1);
+          time = 1;
+          pull(2);
+          time = 2;
+          pull(3);
+          time = 3;
+          pull(4);
+        });
+        assert.deepEqual(cb.args, [[0], [2], [4], [6]]);
       });
       it("has semantic representation", () => {
-        const b = testBehavior((t) => t);
+        const b = B.testBehavior((t) => t);
         const mapped = b.map((t) => t * t);
         const semantic = mapped.semantic();
         assert.strictEqual(semantic(1), 1);
@@ -169,7 +175,7 @@ describe("behavior", () => {
         assert.strictEqual(at(b2), 2);
       });
       it("has semantic representation", () => {
-        const b = testBehavior((t) => {
+        const b = B.testBehavior((t) => {
           throw new Error("Don't call me");
         });
         const mapped = b.mapTo(7);
@@ -192,64 +198,75 @@ describe("behavior", () => {
         const fnB = sinkBehavior(add(1));
         const numE = sinkBehavior(3);
         const applied = B.ap(fnB, numE);
-        const spy = subscribeSpy(applied);
-        assert.equal(B.at(applied), 4);
-        fnB.push(add(2));
-        assert.equal(B.at(applied), 5);
-        numE.push(4);
-        assert.equal(B.at(applied), 6);
-        fnB.push(double);
-        assert.equal(B.at(applied), 8);
-        assert.deepEqual(spy.args, [[4], [5], [6], [8]]);
+        const cb = spy();
+        applied.subscribe(cb);
+        assert.equal(B.at(applied, 1), 4);
+        publish(add(2), fnB);
+        assert.equal(B.at(applied, 2), 5);
+        publish(4, numE);
+        assert.equal(B.at(applied, 3), 6);
+        publish(double, fnB);
+        assert.equal(B.at(applied, 4), 8);
+        assert.deepEqual(cb.args, [[4], [5], [6], [8]]);
       });
       it("applies event of functions to event of numbers with pull", () => {
         let n = 1;
         let fn = add(5);
-        const fnB = fromFunction(() => fn);
-        const numB = fromFunction(() => n);
+        const fnB = B.fromFunction(() => fn);
+        const numB = B.fromFunction(() => n);
         const applied = B.ap(fnB, numB);
-
-        assert.equal(B.at(applied), 6);
-        fn = add(2);
-        assert.equal(B.at(applied), 3);
-        n = 4;
-        assert.equal(B.at(applied), 6);
-        fn = double;
-        assert.equal(B.at(applied), 8);
-        n = 8;
-        assert.equal(B.at(applied), 16);
+        const cb = spy();
+        applied.observe(cb, (pull) => {
+          pull(1);
+          fn = add(2);
+          pull(2);
+          n = 4;
+          pull(3);
+          fn = double;
+          pull(4);
+          n = 8;
+          pull(5);
+          return () => {};
+        });
+        assert.deepEqual(cb.args, [[6], [3], [6], [8], [16]]);
       });
       it("applies pushed event of functions to pulled event of numbers", () => {
         let n = 1;
         const fnB = sinkBehavior(add(5));
-        const numE = B.fromFunction(() => {
-          return n;
-        });
+        const numE = B.fromFunction(() => n);
         const applied = B.ap(fnB, numE);
-        assert.equal(B.at(applied), 6);
-        fnB.push(add(2));
-        assert.equal(B.at(applied), 3);
-        n = 4;
-        assert.equal(B.at(applied), 6);
-        fnB.push(double);
-        assert.equal(B.at(applied), 8);
-        n = 8;
-        assert.equal(B.at(applied), 16);
+        const cb = spy();
+        applied.observe(cb, (pull) => {
+          pull(1);
+          publish(add(2), fnB);
+          pull(2);
+          n = 4;
+          pull(3);
+          publish(double, fnB);
+          pull(4);
+          n = 8;
+          pull(5);
+          return () => {};
+        });
+        assert.deepEqual(cb.args, [[6], [3], [6], [8], [16]]);
       });
     });
     describe("lift", () => {
       it("lifts function of three arguments", () => {
-        const b1 = sinkBehavior(1);
-        const b2 = sinkBehavior(1);
-        const b3 = sinkBehavior(1);
+        const b1 = B.sinkBehavior(1);
+        const b2 = B.sinkBehavior(1);
+        const b3 = B.sinkBehavior(1);
         const lifted = lift((a, b, c) => a * b + c, b1, b2, b3);
+        const cb = spy();
+        lifted.subscribe(cb);
         assert.strictEqual(at(lifted), 2);
-        b2.push(2);
+        publish(2, b2);
         assert.strictEqual(at(lifted), 3);
-        b1.push(3);
+        publish(3, b1);
         assert.strictEqual(at(lifted), 7);
-        b3.push(3);
+        publish(3, b3);
         assert.strictEqual(at(lifted), 9);
+        assert.deepEqual(cb.args, [[2], [3], [7], [9]]);
       });
     });
   });
@@ -257,38 +274,41 @@ describe("behavior", () => {
     it("handles a constant behavior", () => {
       const b1 = Behavior.of(12);
       const b2 = b1.chain((x) => Behavior.of(x * x));
+      b2.observe((v) => {}, () => () => {});
       assert.strictEqual(at(b2), 144);
     });
     it("handles changing outer behavior", () => {
       const b1 = sinkBehavior(0);
       const b2 = b1.chain((x) => Behavior.of(x * x));
-      assert.strictEqual(at(b2), 0);
-      b1.push(2);
-      assert.strictEqual(at(b2), 4);
-      b1.push(3);
-      assert.strictEqual(at(b2), 9);
+      const cb = spy();
+      b2.observe(cb, () => () => {});
+      b1.publish(2, 1);
+      b1.publish(3, 2);
+      assert.deepEqual(cb.args, [[0], [4], [9]]);
     });
     it("handles changing inner behavior", () => {
       const inner = sinkBehavior(0);
       const b = Behavior.of(1).chain((_) => inner);
-      const spy = subscribeSpy(b);
+      const cb = spy();
+      b.observe(cb, () => () => {});
       assert.strictEqual(at(b), 0);
-      inner.push(2);
+      inner.publish(2, 1);
       assert.strictEqual(at(b), 2);
-      inner.push(3);
+      inner.publish(3, 2);
       assert.strictEqual(at(b), 3);
-      assert.deepEqual(spy.args, [[0], [2], [3]]);
+      assert.deepEqual(cb.args, [[0], [2], [3]]);
     });
     it("stops subscribing to past inner behavior", () => {
       const inner = sinkBehavior(0);
       const outer = sinkBehavior(1);
       const b = outer.chain((n) => (n === 1 ? inner : Behavior.of(6)));
+      b.observe(() => {}, () => () => {});
       assert.strictEqual(at(b), 0);
-      inner.push(2);
+      inner.publish(2, 1);
       assert.strictEqual(at(b), 2);
-      outer.push(2);
+      outer.publish(2, 2);
       assert.strictEqual(at(b), 6);
-      inner.push(3);
+      inner.publish(3, 3);
       assert.strictEqual(at(b), 6);
     });
     it("handles changes from both inner and outer", () => {
@@ -304,22 +324,23 @@ describe("behavior", () => {
           return inner2;
         }
       });
+      b.observe(() => {}, () => () => {});
       assert.strictEqual(at(b), 0);
-      outer.push(1);
+      outer.publish(1, 1);
       assert.strictEqual(at(b), 1);
-      inner1.push(2);
+      inner1.publish(2, 2);
       assert.strictEqual(at(b), 2);
-      outer.push(2);
+      outer.publish(2, 3);
       assert.strictEqual(at(b), 3);
-      inner1.push(7); // Pushing to previous inner should have no effect
+      inner1.publish(7, 4); // Pushing to previous inner should have no effect
       assert.strictEqual(at(b), 3);
-      inner2.push(4);
+      inner2.publish(4, 5);
       assert.strictEqual(at(b), 4);
     });
     it("can switch between pulling and pushing", () => {
       const pushingB = sinkBehavior(0);
       let variable = 7;
-      const pullingB = fromFunction(() => variable);
+      const pullingB = B.fromFunction(() => variable);
       const outer = sinkBehavior(true);
       const chained = outer.chain((b) => (b ? pushingB : pullingB));
       const pushSpy = spy();
@@ -328,53 +349,36 @@ describe("behavior", () => {
       const handlePulling = (...args) => {
         beginPullingSpy(...args);
         return endPullingSpy;
-      }
+      };
       // Test that several observers are notified
       chained.observe(pushSpy, handlePulling);
-      chained.observe(pushSpy, handlePulling);
-      chained.observe(pushSpy, handlePulling);
-      pushingB.push(1);
-      pushingB.push(2);
-      outer.push(false);
-      assert.strictEqual(at(chained), 7);
+      pushingB.publish(1, 1);
+      pushingB.publish(2, 2);
+      outer.publish(false, 3);
+      assert.strictEqual(at(chained, 4), 7);
       variable = 8;
-      assert.strictEqual(at(chained), 8);
-      pushingB.push(3);
-      pushingB.push(4);
-      outer.push(true);
-      pushingB.push(5);
-      outer.push(false);
+      assert.strictEqual(at(chained, 5), 8);
+      pushingB.publish(3, 6);
+      pushingB.publish(4, 7);
+      outer.publish(true, 8);
+      pushingB.publish(5, 9);
+      outer.publish(false, 10);
       variable = 9;
-      assert.strictEqual(at(chained), 9);
-      assert.deepEqual(pushSpy.args, [
-        [0],
-        [0],
-        [0],
-        [1],
-        [1],
-        [1],
-        [2],
-        [2],
-        [2],
-        [4],
-        [4],
-        [4],
-        [5],
-        [5],
-        [5]
-      ]);
-      assert.equal(beginPullingSpy.callCount, 6);
-      assert.equal(endPullingSpy.callCount, 3);
+      assert.strictEqual(at(chained, 11), 9);
+      assert.deepEqual(pushSpy.args, [[0], [1], [2], [4], [5]]);
+      assert.equal(beginPullingSpy.callCount, 2);
+      assert.equal(endPullingSpy.callCount, 1);
     });
     it("works with go-notation", () => {
-      const a = sinkBehavior(1);
+      const a = B.sinkBehavior(1);
       const b = go(function*(): IterableIterator<any> {
         const val = yield a;
         return val * 2;
       });
-      const spy = subscribeSpy(b);
-      a.push(7);
-      assert.deepEqual(spy.args, [[2], [14]]);
+      const cb = spy();
+      b.subscribe(cb);
+      a.publish(7, 1);
+      assert.deepEqual(cb.args, [[2], [14]]);
     });
     it("supports adding pullers", () => {
       const b1 = Behavior.of(12);
@@ -392,15 +396,19 @@ describe("behavior", () => {
     it("can integrate", () => {
       const clock = useFakeTimers();
       const acceleration = sinkBehavior(1);
-      const integration = at(integrate(acceleration));
-      assert.strictEqual(at(integration), 0);
+      const Bintergrate = integrate(acceleration);
+      Bintergrate.observe(() => {}, () => () => {});
+      const integration = at(Bintergrate, 1);
+      integration.observe(() => {}, () => () => {});
+      assert.strictEqual(at(integration, 2), 0);
       clock.tick(2000);
-      assert.strictEqual(at(integration), 2);
+      assert.strictEqual(at(integration, 3), 2);
       clock.tick(1000);
-      assert.strictEqual(at(integration), 3);
+      assert.strictEqual(at(integration, 4), 3);
       clock.tick(500);
-      acceleration.push(2);
-      assert.strictEqual(at(integration), 4);
+      acceleration.publish(2, 5);
+      assert.strictEqual(at(integration, 6), 4);
+
       clock.restore();
     });
   });
@@ -411,8 +419,8 @@ describe("behavior", () => {
       const b = format`${bs1} and ${bs2}!`;
       const cb = spy();
       b.subscribe(cb);
-      bs1.push("Hello");
-      bs2.push("goodbye");
+      bs1.publish("Hello", 1);
+      bs2.publish("goodbye", 2);
       assert.deepEqual(cb.args, [
         ["foo and bar!"],
         ["Hello and bar!"],
@@ -425,8 +433,8 @@ describe("behavior", () => {
       const b = format`first ${bs1} then ${bs2}!`;
       const cb = spy();
       b.subscribe(cb);
-      bs1.push("bar");
-      bs2.push(24);
+      bs1.publish("bar", 1);
+      bs2.publish(24, 2);
       assert.deepEqual(cb.args, [
         ["first foo then 12!"],
         ["first bar then 12!"],
@@ -441,10 +449,11 @@ describe("behavior", () => {
       const derived = moment((at) => {
         return at(b1) + at(b2);
       });
-      const spy = subscribeSpy(derived);
-      b1.push(2);
-      b2.push(3);
-      assert.deepEqual(spy.args, [[1], [3], [5]]);
+      const cb = spy();
+      derived.subscribe(cb);
+      b1.publish(2, 1);
+      b2.publish(3, 2);
+      assert.deepEqual(cb.args, [[1], [3], [5]]);
     });
     it("adds and removes dependencies", () => {
       const flag = sinkBehavior(true);
@@ -453,12 +462,13 @@ describe("behavior", () => {
       const derived = moment((at) => {
         return at(flag) ? at(b1) : at(b2);
       });
-      const spy = subscribeSpy(derived);
-      b1.push(4);
-      flag.push(false);
-      b2.push(5);
-      b1.push(6);
-      assert.deepEqual(spy.args, [[2], [4], [3], [5]]);
+      const cb = spy();
+      derived.subscribe(cb);
+      b1.publish(4, 1);
+      flag.publish(false, 2);
+      b2.publish(5, 3);
+      b1.publish(6, 4);
+      assert.deepEqual(cb.args, [[2], [4], [3], [5]]);
     });
     it("can combine behaviors from array", () => {
       const nr1 = sinkBehavior(4);
@@ -467,344 +477,348 @@ describe("behavior", () => {
       const count1 = { count: nr1 };
       const count2 = { count: nr2 };
       const count3 = { count: nr3 };
-      const list: Behavior<{ count: Behavior<number> }[]> = sinkBehavior([]);
+      const list: B.SinkBehavior<{ count: Behavior<number> }[]> = sinkBehavior(
+        []
+      );
       const derived = moment((at) => {
         return at(list)
           .map(({ count }) => at(count))
           .reduce((n, m) => n + m, 0);
       });
-      const spy = subscribeSpy(derived);
-      list.push([count1, count2, count3]);
-      nr2.push(5);
-      list.push([count1, count3]);
-      nr2.push(10);
-      nr3.push(3);
-      assert.deepEqual(spy.args, [[0], [9], [11], [6], [7]]);
-    });
-    it("works with placeholders", () => {
-      const p = placeholder<number>();
-      const b0 = sinkBehavior(3);
-      const b1 = sinkBehavior(1);
-      const b2 = sinkBehavior(2);
-      const derived = moment((at) => {
-        return at(b1) + at(p) + at(b2);
-      });
-      const spy = subscribeSpy(derived);
-      b1.push(2);
-      p.replaceWith(b0);
-      p.push(0);
-      assert.deepEqual(spy.args, [[7], [4]]);
-    });
-    it("works with snapshot", () => {
-      const b1 = sinkBehavior(1);
-      const b2 = moment((at) => at(b1) * 2);
-      const snapped = snapshot(b2, empty);
-      const cb = subscribeSpy(snapped);
-    });
-  });
-});
-
-describe("Behavior and Future", () => {
-  describe("when", () => {
-    it("gives occurred future when behavior is true", () => {
-      let occurred = false;
-      const b = Behavior.of(true);
-      const w = B.when(b);
-      const fut = at(w);
-      fut.subscribe((_) => (occurred = true));
-      assert.strictEqual(occurred, true);
-    });
-    it("future occurs when behavior turns true", () => {
-      let occurred = false;
-      const b = sinkBehavior(false);
-      const w = B.when(b);
-      const fut = at(w);
-      fut.subscribe((_) => (occurred = true));
-      assert.strictEqual(occurred, false);
-      b.push(true);
-      assert.strictEqual(occurred, true);
-    });
-  });
-  describe("snapshotAt", () => {
-    it("snapshots behavior at future occurring in future", () => {
-      let result: number;
-      const bSink = sinkBehavior(1);
-      const futureSink = F.sinkFuture();
-      const mySnapshot = at(B.snapshotAt(bSink, futureSink));
-      mySnapshot.subscribe((res) => (result = res));
-      bSink.push(2);
-      bSink.push(3);
-      futureSink.resolve({});
-      bSink.push(4);
-      assert.strictEqual(result, 3);
-    });
-    it("uses current value when future occurred in the past", () => {
-      let result: number;
-      const bSink = sinkBehavior(1);
-      const occurredFuture = Future.of({});
-      bSink.push(2);
-      const mySnapshot = at(B.snapshotAt(bSink, occurredFuture));
-      mySnapshot.subscribe((res) => (result = res));
-      bSink.push(3);
-      assert.strictEqual(result, 2);
-    });
-  });
-  describe("switchTo", () => {
-    it("switches to new behavior", () => {
-      const b1 = sinkBehavior(1);
-      const b2 = sinkBehavior(8);
-      const futureSink = F.sinkFuture<Behavior<number>>();
-      const switching = switchTo(b1, futureSink);
-      assert.strictEqual(at(switching), 1);
-      b2.push(9);
-      assert.strictEqual(at(switching), 1);
-      b1.push(2);
-      assert.strictEqual(at(switching), 2);
-      b1.push(3);
-      assert.strictEqual(at(switching), 3);
-      futureSink.resolve(b2);
-      assert.strictEqual(at(switching), 9);
-      b2.push(10);
-      assert.strictEqual(at(switching), 10);
-    });
-    it("changes from push to pull", () => {
-      const pushSpy = spy();
-      const beginPullingSpy = spy();
-      const endPullingSpy = spy();
-      const handlePulling = (...args) => {
-        beginPullingSpy(...args);
-        return endPullingSpy;
-      }
-
-      const pushingB = sinkBehavior(0);
-      let x = 7;
-      const pullingB = fromFunction(() => x);
-      const futureSink = F.sinkFuture<Behavior<number>>();
-      const switching = switchTo(pushingB, futureSink);
-      observe(pushSpy, handlePulling, switching);
-      assert.strictEqual(at(switching), 0);
-      pushingB.push(1);
-      assert.strictEqual(at(switching), 1);
-      futureSink.resolve(pullingB);
-      assert.strictEqual(at(switching), 7);
-      x = 8;
-      assert.strictEqual(at(switching), 8);
-      assert.strictEqual(beginPullingSpy.callCount, 1);
-      assert.strictEqual(endPullingSpy.callCount, 0);
-    });
-    it("changes from pull to push", () => {
-      let beginPull = false;
-      let endPull = false;
-      let pushed: number[] = [];
-      let x = 0;
-      const b1 = B.fromFunction(() => x);
-      const b2 = sinkBehavior(2);
-      const futureSink = F.sinkFuture<Behavior<number>>();
-      const switching = switchTo(b1, futureSink);
-      observe(
-        (n: number) => pushed.push(n),
-        () => {
-          beginPull = true
-          return () => {endPull = true}; 
-        },
-        switching
-      );
-      assert.strictEqual(beginPull, true);
-      assert.strictEqual(at(switching), 0);
-      x = 1;
-      assert.strictEqual(at(switching), 1);
-      assert.strictEqual(endPull, false);
-      futureSink.resolve(b2);
-      assert.strictEqual(endPull, true);
-      b2.push(3);
-      assert.deepEqual(pushed, [2, 3]);
-    });
-  });
-});
-
-describe("Behavior and Stream", () => {
-  describe("switcher", () => {
-    it("switches to behavior", () => {
-      const result: number[] = [];
-      const stream = sinkStream<Behavior<number>>();
-      const initB = Behavior.of(1);
-      const outerSwitcher = switcher(initB, stream);
-      const switchingB = at(outerSwitcher);
-      switchingB.subscribe((n) => result.push(n));
-      const sinkB = sinkBehavior(2);
-      stream.push(sinkB);
-      sinkB.push(3);
-      assert.deepEqual(result, [1, 2, 3]);
-      assert.deepEqual(at(at(outerSwitcher)), 1);
-    });
-  });
-  describe("stepper", () => {
-    it("steps to the last event value", () => {
-      const s = sinkStream();
-      const b = stepper(0, s).at();
-      const cb = subscribeSpy(b);
-      s.push(1);
-      s.push(2);
-      assert.deepEqual(cb.args, [[0], [1], [2]]);
-    });
-    it("saves last occurrence from stream", () => {
-      const s = sinkStream();
-      const t = stepper(1, s).at();
-      s.push(12);
-      const spy = subscribeSpy(t);
-      assert.deepEqual(spy.args, [[12]]);
-    });
-    it("has old value in exact moment", () => {
-      const s = sinkStream();
-      const b = stepper(0, s).at();
-      const res = snapshot(b, s);
-      const spy = subscribeSpy(res);
-      s.push(1);
-      assert.strictEqual(b.at(), 1);
-      s.push(2);
-      assert.strictEqual(b.at(), 2);
-      assert.deepEqual(spy.args, [[0], [1]]);
-    });
-  });
-  describe("scan", () => {
-    it("has scan as method on stream", () => {
-      const scanned = empty.scan(sum, 0);
-    });
-    it("accumulates in a pure way", () => {
-      const s = sinkStream<number>();
-      const scanned = scan(sum, 1, s);
-      const b1 = scanned.at();
-      const spy = subscribeSpy(b1);
-      assert.strictEqual(at(b1), 1);
-      s.push(2);
-      assert.strictEqual(at(b1), 3);
-      const b2 = at(scanned);
-      assert.strictEqual(at(b2), 1);
-      s.push(4);
-      assert.strictEqual(at(b1), 7);
-      assert.strictEqual(at(b2), 5);
-      assert.deepEqual(spy.args, [[1], [3], [7]]);
-    });
-    it("has semantic representation", () => {
-      const s = testStreamFromObject({
-        1: 1,
-        2: 1,
-        4: 2,
-        6: 3,
-        7: 1
-      });
-      const scanned = scan((n, m) => n + m, 0, s);
-      const semantic = scanned.semantic();
-
-      const from0 = semantic(0).semantic();
-      assert.strictEqual(from0(0), 0);
-      assert.strictEqual(from0(1), 1);
-      assert.strictEqual(from0(2), 2);
-      assert.strictEqual(from0(3), 2);
-      assert.strictEqual(from0(4), 4);
-
-      const from3 = semantic(3).semantic();
-      assert.strictEqual(from3(3), 0);
-      assert.strictEqual(from3(4), 2);
-      assert.strictEqual(from3(5), 2);
-      assert.strictEqual(from3(6), 5);
-      assert.strictEqual(from3(7), 6);
-    });
-  });
-  describe("scanCombine", () => {
-    it("combines several streams", () => {
-      const add = sinkStream();
-      const sub = sinkStream();
-      const mul = sinkStream();
-      const b = scanCombine(
-        [
-          [add, (n, m) => n + m],
-          [sub, (n, m) => m - n],
-          [mul, (n, m) => n * m]
-        ],
-        1
-      );
-      const cb = subscribeSpy(b.at());
-      add.push(3);
-      mul.push(3);
-      sub.push(5);
-      assert.deepEqual(cb.args, [[1], [4], [12], [7]]);
-    });
-  });
-  describe("switchStream", () => {
-    it("returns stream that emits from stream", () => {
-      const s1 = sinkStream();
-      const s2 = sinkStream();
-      const s3 = sinkStream();
-      const b = sinkBehavior(s1);
-      const switching = switchStream(b);
       const cb = spy();
-      switching.subscribe(cb);
-      s1.push(1);
-      s1.push(2);
-      b.push(s2);
-      s2.push(3);
-      b.push(s3);
-      s2.push(4);
-      s3.push(5);
-      s3.push(6);
-      assert.deepEqual(cb.args, [[1], [2], [3], [5], [6]]);
+      derived.subscribe(cb);
+      list.publish([count1, count2, count3], 1);
+      nr2.publish(5, 2);
+      list.publish([count1, count3], 3);
+      nr2.publish(10, 4);
+      nr3.publish(3, 5);
+      assert.deepEqual(cb.args, [[0], [9], [11], [6], [7]]);
     });
+    // it("works with placeholders", () => {
+    //   const p = placeholder<number>();
+    //   const b0 = sinkBehavior(3);
+    //   const b1 = sinkBehavior(1);
+    //   const b2 = sinkBehavior(2);
+    //   const derived = moment((at) => {
+    //     return at(b1) + at(p) + at(b2);
+    //   });
+    //   const cb = spy();
+    //   derived.subscribe(cb);
+    //   b1.publish(2, 1);
+    //   p.replaceWith(b0);
+    //   p.publish(0, 2);
+    //   assert.deepEqual(cb.args, [[7], [4]]);
+    // });
+    // it("works with snapshot", () => {
+    //   const b1 = sinkBehavior(1);
+    //   const b2 = moment((at) => at(b1) * 2);
+    //   const snapped = snapshot(b2, empty);
+    //   const cb = subscribeSpy(snapped);
+    // });
   });
-  describe("continuous time", () => {
-    it("gives time from sample point", () => {
-      const [setTime, restore] = mockNow();
-      setTime(3);
-      const time = at(timeFrom);
-      assert.strictEqual(at(time), 0);
-      setTime(4);
-      assert.strictEqual(at(time), 1);
-      setTime(7);
-      assert.strictEqual(at(time), 4);
-      restore();
-    });
-    it("gives time since UNIX epoch", () => {
-      let beginPull = false;
-      let endPull = false;
-      let pushed: number[] = [];
-      observe(
-        (n: number) => pushed.push(n),
-        () => { 
-          beginPull = true;
-          return () => {endPull = true}
-        },
-        time
-      );
-      assert.strictEqual(beginPull, true);
-      const t = at(time);
-      const now = Date.now();
-      assert(now - 2 <= t && t <= now);
-      assert.strictEqual(endPull, false);
-    });
-    it("has semantic representation", () => {
-      const f = time.semantic();
-      assert.strictEqual(f(0), 0);
-      assert.strictEqual(f(1.3), 1.3);
-    });
-  });
-  describe("toggle", () => {
-    it("has correct initial value", () => {
-      const s1 = sinkStream();
-      const s2 = sinkStream();
-      const flipper1 = toggle(true, s1, s2).at();
-      assert.strictEqual(at(flipper1), true);
-      const flipper2 = toggle(false, s1, s2).at();
-      assert.strictEqual(at(flipper2), false);
-    });
-    it("flips properly", () => {
-      const s1 = sinkStream();
-      const s2 = sinkStream();
-      const flipper = toggle(false, s1, s2).at();
-      const cb = subscribeSpy(flipper);
-      s1.push(1);
-      s2.push(2);
-      s1.push(3);
-      assert.deepEqual(cb.args, [[false], [true], [false], [true]]);
-    });
-  });
+  // });
+
+  // describe("Behavior and Future", () => {
+  //   describe("when", () => {
+  //     it("gives occurred future when behavior is true", () => {
+  //       let occurred = false;
+  //       const b = Behavior.of(true);
+  //       const w = B.when(b);
+  //       const fut = at(w);
+  //       fut.subscribe((_) => (occurred = true));
+  //       assert.strictEqual(occurred, true);
+  //     });
+  //     it("future occurs when behavior turns true", () => {
+  //       let occurred = false;
+  //       const b = sinkBehavior(false);
+  //       const w = B.when(b);
+  //       const fut = at(w);
+  //       fut.subscribe((_) => (occurred = true));
+  //       assert.strictEqual(occurred, false);
+  //       b.push(true);
+  //       assert.strictEqual(occurred, true);
+  //     });
+  //   });
+  //   describe("snapshotAt", () => {
+  //     it("snapshots behavior at future occurring in future", () => {
+  //       let result: number;
+  //       const bSink = sinkBehavior(1);
+  //       const futureSink = F.sinkFuture();
+  //       const mySnapshot = at(B.snapshotAt(bSink, futureSink));
+  //       mySnapshot.subscribe((res) => (result = res));
+  //       bSink.push(2);
+  //       bSink.push(3);
+  //       futureSink.resolve({});
+  //       bSink.push(4);
+  //       assert.strictEqual(result, 3);
+  //     });
+  //     it("uses current value when future occurred in the past", () => {
+  //       let result: number;
+  //       const bSink = sinkBehavior(1);
+  //       const occurredFuture = Future.of({});
+  //       bSink.push(2);
+  //       const mySnapshot = at(B.snapshotAt(bSink, occurredFuture));
+  //       mySnapshot.subscribe((res) => (result = res));
+  //       bSink.push(3);
+  //       assert.strictEqual(result, 2);
+  //     });
+  //   });
+  //   describe("switchTo", () => {
+  //     it("switches to new behavior", () => {
+  //       const b1 = sinkBehavior(1);
+  //       const b2 = sinkBehavior(8);
+  //       const futureSink = F.sinkFuture<Behavior<number>>();
+  //       const switching = switchTo(b1, futureSink);
+  //       assert.strictEqual(at(switching), 1);
+  //       b2.push(9);
+  //       assert.strictEqual(at(switching), 1);
+  //       b1.push(2);
+  //       assert.strictEqual(at(switching), 2);
+  //       b1.push(3);
+  //       assert.strictEqual(at(switching), 3);
+  //       futureSink.resolve(b2);
+  //       assert.strictEqual(at(switching), 9);
+  //       b2.push(10);
+  //       assert.strictEqual(at(switching), 10);
+  //     });
+  //     it("changes from push to pull", () => {
+  //       const pushSpy = spy();
+  //       const beginPullingSpy = spy();
+  //       const endPullingSpy = spy();
+  //       const handlePulling = (...args) => {
+  //         beginPullingSpy(...args);
+  //         return endPullingSpy;
+  //       }
+
+  //       const pushingB = sinkBehavior(0);
+  //       let x = 7;
+  //       const pullingB = fromFunction(() => x);
+  //       const futureSink = F.sinkFuture<Behavior<number>>();
+  //       const switching = switchTo(pushingB, futureSink);
+  //       observe(pushSpy, handlePulling, switching);
+  //       assert.strictEqual(at(switching), 0);
+  //       pushingB.push(1);
+  //       assert.strictEqual(at(switching), 1);
+  //       futureSink.resolve(pullingB);
+  //       assert.strictEqual(at(switching), 7);
+  //       x = 8;
+  //       assert.strictEqual(at(switching), 8);
+  //       assert.strictEqual(beginPullingSpy.callCount, 1);
+  //       assert.strictEqual(endPullingSpy.callCount, 0);
+  //     });
+  //     it("changes from pull to push", () => {
+  //       let beginPull = false;
+  //       let endPull = false;
+  //       let pushed: number[] = [];
+  //       let x = 0;
+  //       const b1 = B.fromFunction(() => x);
+  //       const b2 = sinkBehavior(2);
+  //       const futureSink = F.sinkFuture<Behavior<number>>();
+  //       const switching = switchTo(b1, futureSink);
+  //       observe(
+  //         (n: number) => pushed.push(n),
+  //         () => {
+  //           beginPull = true
+  //           return () => {endPull = true};
+  //         },
+  //         switching
+  //       );
+  //       assert.strictEqual(beginPull, true);
+  //       assert.strictEqual(at(switching), 0);
+  //       x = 1;
+  //       assert.strictEqual(at(switching), 1);
+  //       assert.strictEqual(endPull, false);
+  //       futureSink.resolve(b2);
+  //       assert.strictEqual(endPull, true);
+  //       b2.push(3);
+  //       assert.deepEqual(pushed, [2, 3]);
+  //     });
+  //   });
+  // });
+
+  // describe("Behavior and Stream", () => {
+  //   describe("switcher", () => {
+  //     it("switches to behavior", () => {
+  //       const result: number[] = [];
+  //       const stream = sinkStream<Behavior<number>>();
+  //       const initB = Behavior.of(1);
+  //       const outerSwitcher = switcher(initB, stream);
+  //       const switchingB = at(outerSwitcher);
+  //       switchingB.subscribe((n) => result.push(n));
+  //       const sinkB = sinkBehavior(2);
+  //       stream.push(sinkB);
+  //       sinkB.push(3);
+  //       assert.deepEqual(result, [1, 2, 3]);
+  //       assert.deepEqual(at(at(outerSwitcher)), 1);
+  //     });
+  //   });
+  //   describe("stepper", () => {
+  //     it("steps to the last event value", () => {
+  //       const s = sinkStream();
+  //       const b = stepper(0, s).at();
+  //       const cb = subscribeSpy(b);
+  //       s.push(1);
+  //       s.push(2);
+  //       assert.deepEqual(cb.args, [[0], [1], [2]]);
+  //     });
+  //     it("saves last occurrence from stream", () => {
+  //       const s = sinkStream();
+  //       const t = stepper(1, s).at();
+  //       s.push(12);
+  //       const spy = subscribeSpy(t);
+  //       assert.deepEqual(spy.args, [[12]]);
+  //     });
+  //     it("has old value in exact moment", () => {
+  //       const s = sinkStream();
+  //       const b = stepper(0, s).at();
+  //       const res = snapshot(b, s);
+  //       const spy = subscribeSpy(res);
+  //       s.push(1);
+  //       assert.strictEqual(b.at(), 1);
+  //       s.push(2);
+  //       assert.strictEqual(b.at(), 2);
+  //       assert.deepEqual(spy.args, [[0], [1]]);
+  //     });
+  //   });
+  //   describe("scan", () => {
+  //     it("has scan as method on stream", () => {
+  //       const scanned = empty.scan(sum, 0);
+  //     });
+  //     it("accumulates in a pure way", () => {
+  //       const s = sinkStream<number>();
+  //       const scanned = scan(sum, 1, s);
+  //       const b1 = scanned.at();
+  //       const spy = subscribeSpy(b1);
+  //       assert.strictEqual(at(b1), 1);
+  //       s.push(2);
+  //       assert.strictEqual(at(b1), 3);
+  //       const b2 = at(scanned);
+  //       assert.strictEqual(at(b2), 1);
+  //       s.push(4);
+  //       assert.strictEqual(at(b1), 7);
+  //       assert.strictEqual(at(b2), 5);
+  //       assert.deepEqual(spy.args, [[1], [3], [7]]);
+  //     });
+  //     it("has semantic representation", () => {
+  //       const s = testStreamFromObject({
+  //         1: 1,
+  //         2: 1,
+  //         4: 2,
+  //         6: 3,
+  //         7: 1
+  //       });
+  //       const scanned = scan((n, m) => n + m, 0, s);
+  //       const semantic = scanned.semantic();
+
+  //       const from0 = semantic(0).semantic();
+  //       assert.strictEqual(from0(0), 0);
+  //       assert.strictEqual(from0(1), 1);
+  //       assert.strictEqual(from0(2), 2);
+  //       assert.strictEqual(from0(3), 2);
+  //       assert.strictEqual(from0(4), 4);
+
+  //       const from3 = semantic(3).semantic();
+  //       assert.strictEqual(from3(3), 0);
+  //       assert.strictEqual(from3(4), 2);
+  //       assert.strictEqual(from3(5), 2);
+  //       assert.strictEqual(from3(6), 5);
+  //       assert.strictEqual(from3(7), 6);
+  //     });
+  //   });
+  //   describe("scanCombine", () => {
+  //     it("combines several streams", () => {
+  //       const add = sinkStream();
+  //       const sub = sinkStream();
+  //       const mul = sinkStream();
+  //       const b = scanCombine(
+  //         [
+  //           [add, (n, m) => n + m],
+  //           [sub, (n, m) => m - n],
+  //           [mul, (n, m) => n * m]
+  //         ],
+  //         1
+  //       );
+  //       const cb = subscribeSpy(b.at());
+  //       add.push(3);
+  //       mul.push(3);
+  //       sub.push(5);
+  //       assert.deepEqual(cb.args, [[1], [4], [12], [7]]);
+  //     });
+  //   });
+  //   describe("switchStream", () => {
+  //     it("returns stream that emits from stream", () => {
+  //       const s1 = sinkStream();
+  //       const s2 = sinkStream();
+  //       const s3 = sinkStream();
+  //       const b = sinkBehavior(s1);
+  //       const switching = switchStream(b);
+  //       const cb = spy();
+  //       switching.subscribe(cb);
+  //       s1.push(1);
+  //       s1.push(2);
+  //       b.push(s2);
+  //       s2.push(3);
+  //       b.push(s3);
+  //       s2.push(4);
+  //       s3.push(5);
+  //       s3.push(6);
+  //       assert.deepEqual(cb.args, [[1], [2], [3], [5], [6]]);
+  //     });
+  //   });
+  //   describe("continuous time", () => {
+  //     it("gives time from sample point", () => {
+  //       const [setTime, restore] = mockNow();
+  //       setTime(3);
+  //       const time = at(timeFrom);
+  //       assert.strictEqual(at(time), 0);
+  //       setTime(4);
+  //       assert.strictEqual(at(time), 1);
+  //       setTime(7);
+  //       assert.strictEqual(at(time), 4);
+  //       restore();
+  //     });
+  //     it("gives time since UNIX epoch", () => {
+  //       let beginPull = false;
+  //       let endPull = false;
+  //       let pushed: number[] = [];
+  //       observe(
+  //         (n: number) => pushed.push(n),
+  //         () => {
+  //           beginPull = true;
+  //           return () => {endPull = true}
+  //         },
+  //         time
+  //       );
+  //       assert.strictEqual(beginPull, true);
+  //       const t = at(time);
+  //       const now = Date.now();
+  //       assert(now - 2 <= t && t <= now);
+  //       assert.strictEqual(endPull, false);
+  //     });
+  //     it("has semantic representation", () => {
+  //       const f = time.semantic();
+  //       assert.strictEqual(f(0), 0);
+  //       assert.strictEqual(f(1.3), 1.3);
+  //     });
+  //   });
+  //   describe("toggle", () => {
+  //     it("has correct initial value", () => {
+  //       const s1 = sinkStream();
+  //       const s2 = sinkStream();
+  //       const flipper1 = toggle(true, s1, s2).at();
+  //       assert.strictEqual(at(flipper1), true);
+  //       const flipper2 = toggle(false, s1, s2).at();
+  //       assert.strictEqual(at(flipper2), false);
+  //     });
+  //     it("flips properly", () => {
+  //       const s1 = sinkStream();
+  //       const s2 = sinkStream();
+  //       const flipper = toggle(false, s1, s2).at();
+  //       const cb = subscribeSpy(flipper);
+  //       s1.push(1);
+  //       s2.push(2);
+  //       s1.push(3);
+  //       assert.deepEqual(cb.args, [[false], [true], [false], [true]]);
+  //     });
+  //   });
 });

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -267,8 +267,8 @@ describe("behavior", () => {
       const b2 = b1.chain((x) => Behavior.of(x * x));
       const cb = spy();
       b2.observe(cb, () => () => {});
-      b1.publish(2);
-      b1.publish(3);
+      b1.push(2);
+      b1.push(3);
       assert.deepEqual(cb.args, [[0], [4], [9]]);
     });
     it("handles changing inner behavior", () => {
@@ -277,9 +277,9 @@ describe("behavior", () => {
       const cb = spy();
       b.observe(cb, () => () => {});
       assert.strictEqual(at(b), 0);
-      inner.publish(2);
+      inner.push(2);
       assert.strictEqual(at(b), 2);
-      inner.publish(3);
+      inner.push(3);
       assert.strictEqual(at(b), 3);
       assert.deepEqual(cb.args, [[0], [2], [3]]);
     });
@@ -289,11 +289,11 @@ describe("behavior", () => {
       const b = outer.chain((n) => (n === 1 ? inner : Behavior.of(6)));
       b.observe(() => {}, () => () => {});
       assert.strictEqual(at(b), 0);
-      inner.publish(2);
+      inner.push(2);
       assert.strictEqual(at(b), 2);
-      outer.publish(2);
+      outer.push(2);
       assert.strictEqual(at(b), 6);
-      inner.publish(3);
+      inner.push(3);
       assert.strictEqual(at(b), 6);
     });
     it("handles changes from both inner and outer", () => {
@@ -311,15 +311,15 @@ describe("behavior", () => {
       });
       b.observe(() => {}, () => () => {});
       assert.strictEqual(at(b), 0);
-      outer.publish(1);
+      outer.push(1);
       assert.strictEqual(at(b), 1);
-      inner1.publish(2);
+      inner1.push(2);
       assert.strictEqual(at(b), 2);
-      outer.publish(2);
+      outer.push(2);
       assert.strictEqual(at(b), 3);
-      inner1.publish(7); // Pushing to previous inner should have no effect
+      inner1.push(7); // Pushing to previous inner should have no effect
       assert.strictEqual(at(b), 3);
-      inner2.publish(4);
+      inner2.push(4);
       assert.strictEqual(at(b), 4);
     });
     it("can switch between pulling and pushing", () => {
@@ -337,17 +337,17 @@ describe("behavior", () => {
       };
       // Test that several observers are notified
       chained.observe(pushSpy, handlePulling);
-      pushingB.publish(1);
-      pushingB.publish(2);
-      outer.publish(false);
+      pushingB.push(1);
+      pushingB.push(2);
+      outer.push(false);
       assert.strictEqual(at(chained), 7);
       variable = 8;
       assert.strictEqual(at(chained), 8);
-      pushingB.publish(3);
-      pushingB.publish(4);
-      outer.publish(true);
-      pushingB.publish(5);
-      outer.publish(false);
+      pushingB.push(3);
+      pushingB.push(4);
+      outer.push(true);
+      pushingB.push(5);
+      outer.push(false);
       variable = 9;
       assert.strictEqual(at(chained), 9);
       assert.deepEqual(pushSpy.args, [[0], [1], [2], [4], [5]]);
@@ -362,7 +362,7 @@ describe("behavior", () => {
       });
       const cb = spy();
       b.subscribe(cb);
-      a.publish(7);
+      a.push(7);
       assert.deepEqual(cb.args, [[2], [14]]);
     });
     it("supports adding pullers", () => {
@@ -391,7 +391,7 @@ describe("behavior", () => {
       clock.tick(1000);
       assert.strictEqual(at(integration), 3);
       clock.tick(500);
-      acceleration.publish(2);
+      acceleration.push(2);
       assert.strictEqual(at(integration), 4);
 
       clock.restore();
@@ -404,8 +404,8 @@ describe("behavior", () => {
       const b = format`${bs1} and ${bs2}!`;
       const cb = spy();
       b.subscribe(cb);
-      bs1.publish("Hello");
-      bs2.publish("goodbye");
+      bs1.push("Hello");
+      bs2.push("goodbye");
       assert.deepEqual(cb.args, [
         ["foo and bar!"],
         ["Hello and bar!"],
@@ -418,8 +418,8 @@ describe("behavior", () => {
       const b = format`first ${bs1} then ${bs2}!`;
       const cb = spy();
       b.subscribe(cb);
-      bs1.publish("bar");
-      bs2.publish(24);
+      bs1.push("bar");
+      bs2.push(24);
       assert.deepEqual(cb.args, [
         ["first foo then 12!"],
         ["first bar then 12!"],
@@ -436,8 +436,8 @@ describe("behavior", () => {
       });
       const cb = spy();
       derived.subscribe(cb);
-      b1.publish(2);
-      b2.publish(3);
+      b1.push(2);
+      b2.push(3);
       assert.deepEqual(cb.args, [[1], [3], [5]]);
     });
     it("adds and removes dependencies", () => {
@@ -449,10 +449,10 @@ describe("behavior", () => {
       });
       const cb = spy();
       derived.subscribe(cb);
-      b1.publish(4);
-      flag.publish(false);
-      b2.publish(5);
-      b1.publish(6);
+      b1.push(4);
+      flag.push(false);
+      b2.push(5);
+      b1.push(6);
       assert.deepEqual(cb.args, [[2], [4], [3], [5]]);
     });
     it("can combine behaviors from array", () => {
@@ -472,11 +472,11 @@ describe("behavior", () => {
       });
       const cb = spy();
       derived.subscribe(cb);
-      list.publish([count1, count2, count3]);
-      nr2.publish(5);
-      list.publish([count1, count3]);
-      nr2.publish(10);
-      nr3.publish(3);
+      list.push([count1, count2, count3]);
+      nr2.push(5);
+      list.push([count1, count3]);
+      nr2.push(10);
+      nr3.push(3);
       assert.deepEqual(cb.args, [[0], [9], [11], [6], [7]]);
     });
     it("works with placeholders", () => {
@@ -489,9 +489,9 @@ describe("behavior", () => {
       });
       const cb = spy();
       derived.subscribe(cb);
-      b1.publish(2);
+      b1.push(2);
       p.replaceWith(b0);
-      b0.publish(0);
+      b0.push(0);
       assert.deepEqual(cb.args, [[7], [4]]);
     });
     it("works with snapshot", () => {
@@ -520,7 +520,7 @@ describe("Behavior and Future", () => {
       const fut = at(w);
       fut.subscribe((_) => (occurred = true));
       assert.strictEqual(occurred, false);
-      b.publish(true);
+      b.push(true);
       assert.strictEqual(occurred, true);
     });
   });
@@ -531,20 +531,20 @@ describe("Behavior and Future", () => {
       const futureSink = H.sinkFuture();
       const mySnapshot = at(H.snapshotAt(bSink, futureSink));
       mySnapshot.subscribe((res) => (result = res));
-      bSink.publish(2);
-      bSink.publish(3);
+      bSink.push(2);
+      bSink.push(3);
       futureSink.resolve({});
-      bSink.publish(4);
+      bSink.push(4);
       assert.strictEqual(result, 3);
     });
     it("uses current value when future occurred in the past", () => {
       let result: number;
       const bSink = sinkBehavior(1);
       const occurredFuture = H.Future.of({});
-      bSink.publish(2);
+      bSink.push(2);
       const mySnapshot = at(H.snapshotAt(bSink, occurredFuture));
       mySnapshot.subscribe((res) => (result = res));
-      bSink.publish(3);
+      bSink.push(3);
       assert.strictEqual(result, 2);
     });
   });
@@ -556,12 +556,12 @@ describe("Behavior and Future", () => {
       const switching = switchTo(b1, futureSink);
       const cb = subscribeSpy(switching);
       assert.strictEqual(at(switching), 1);
-      b2.publish(9);
+      b2.push(9);
       assert.strictEqual(at(switching), 1);
-      b1.publish(2);
-      b1.publish(3);
+      b1.push(2);
+      b1.push(3);
       futureSink.resolve(b2);
-      b2.publish(10);
+      b2.push(10);
       assert.deepEqual(cb.args, [[1], [2], [3], [9], [10]]);
     });
     it("changes from push to pull", () => {
@@ -579,7 +579,7 @@ describe("Behavior and Future", () => {
       const switching = switchTo(pushingB, futureSink);
       observe(pushSpy, handlePulling, switching);
       assert.strictEqual(at(switching), 0);
-      pushingB.publish(1);
+      pushingB.push(1);
       assert.strictEqual(at(switching), 1);
       futureSink.resolve(pullingB);
       assert.strictEqual(at(switching), 7);
@@ -614,7 +614,7 @@ describe("Behavior and Future", () => {
       assert.strictEqual(endPull, false);
       futureSink.resolve(b2);
       assert.strictEqual(endPull, true);
-      b2.publish(3);
+      b2.push(3);
       assert.deepEqual(pushed, [2, 3]);
     });
   });
@@ -629,8 +629,8 @@ describe("Behavior and Stream", () => {
       const switchingB = at(outerSwitcher);
       switchingB.subscribe((n) => result.push(n));
       const sinkB = sinkBehavior(2);
-      stream.publish(sinkB);
-      sinkB.publish(3);
+      stream.push(sinkB);
+      sinkB.push(3);
       assert.deepEqual(result, [1, 2, 3]);
       assert.deepEqual(at(at(outerSwitcher)), 1);
     });
@@ -640,14 +640,14 @@ describe("Behavior and Stream", () => {
       const s = H.sinkStream();
       const b = H.stepper(0, s).at();
       const cb = subscribeSpy(b);
-      s.publish(1);
-      s.publish(2);
+      s.push(1);
+      s.push(2);
       assert.deepEqual(cb.args, [[0], [1], [2]]);
     });
     it("saves last occurrence from stream", () => {
       const s = H.sinkStream();
       const t = H.stepper(1, s).at();
-      s.publish(12);
+      s.push(12);
       const spy = subscribeSpy(t);
       assert.deepEqual(spy.args, [[12]]);
     });
@@ -656,9 +656,9 @@ describe("Behavior and Stream", () => {
       const b = H.stepper(0, s).at();
       const res = H.snapshot(b, s);
       const spy = subscribeSpy(res);
-      s.publish(1);
+      s.push(1);
       assert.strictEqual(b.at(), 1);
-      s.publish(2);
+      s.push(2);
       assert.strictEqual(b.at(), 2);
       assert.deepEqual(spy.args, [[0], [1]]);
     });
@@ -673,11 +673,11 @@ describe("Behavior and Stream", () => {
       const b1 = scanned.at();
       const spy = subscribeSpy(b1);
       assert.strictEqual(at(b1), 1);
-      s.publish(2);
+      s.push(2);
       assert.strictEqual(at(b1), 3);
       const b2 = at(scanned);
       assert.strictEqual(at(b2), 1);
-      s.publish(4);
+      s.push(4);
       assert.strictEqual(at(b1), 7);
       assert.strictEqual(at(b2), 5);
       assert.deepEqual(spy.args, [[1], [3], [7]]);
@@ -720,9 +720,9 @@ describe("Behavior and Stream", () => {
         1
       );
       const cb = subscribeSpy(b.at());
-      add.publish(3);
-      mul.publish(3);
-      sub.publish(5);
+      add.push(3);
+      mul.push(3);
+      sub.push(5);
       assert.deepEqual(cb.args, [[1], [4], [12], [7]]);
     });
   });
@@ -735,14 +735,14 @@ describe("Behavior and Stream", () => {
       const switching = H.switchStream(b);
       const cb = spy();
       switching.subscribe(cb);
-      s1.publish(1);
-      s1.publish(2);
-      b.publish(s2);
-      s2.publish(3);
-      b.publish(s3);
-      s2.publish(4);
-      s3.publish(5);
-      s3.publish(6);
+      s1.push(1);
+      s1.push(2);
+      b.push(s2);
+      s2.push(3);
+      b.push(s3);
+      s2.push(4);
+      s3.push(5);
+      s3.push(6);
       assert.deepEqual(cb.args, [[1], [2], [3], [5], [6]]);
     });
   });
@@ -798,9 +798,9 @@ describe("Behavior and Stream", () => {
       const s2 = H.sinkStream();
       const flipper = H.toggle(false, s1, s2).at();
       const cb = subscribeSpy(flipper);
-      s1.publish(1);
-      s2.publish(2);
-      s1.publish(3);
+      s1.push(1);
+      s2.push(2);
+      s1.push(3);
       assert.deepEqual(cb.args, [[false], [true], [false], [true]]);
     });
   });

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -505,50 +505,50 @@ describe("behavior", () => {
 });
 
 describe("Behavior and Future", () => {
-  // describe("when", () => {
-  // it("gives occurred future when behavior is true", () => {
-  //   let occurred = false;
-  //   const b = Behavior.of(true);
-  //   const w = B.when(b);
-  //   const fut = at(w);
-  //   fut.subscribe((_) => (occurred = true));
-  //   assert.strictEqual(occurred, true);
-  // });
-  //     it("future occurs when behavior turns true", () => {
-  //       let occurred = false;
-  //       const b = sinkBehavior(false);
-  //       const w = B.when(b);
-  //       const fut = at(w);
-  //       fut.subscribe((_) => (occurred = true));
-  //       assert.strictEqual(occurred, false);
-  //       b.push(true);
-  //       assert.strictEqual(occurred, true);
-  //     });
-  // });
-  //   describe("snapshotAt", () => {
-  //     it("snapshots behavior at future occurring in future", () => {
-  //       let result: number;
-  //       const bSink = sinkBehavior(1);
-  //       const futureSink = F.sinkFuture();
-  //       const mySnapshot = at(B.snapshotAt(bSink, futureSink));
-  //       mySnapshot.subscribe((res) => (result = res));
-  //       bSink.push(2);
-  //       bSink.push(3);
-  //       futureSink.resolve({});
-  //       bSink.push(4);
-  //       assert.strictEqual(result, 3);
-  //     });
-  //     it("uses current value when future occurred in the past", () => {
-  //       let result: number;
-  //       const bSink = sinkBehavior(1);
-  //       const occurredFuture = Future.of({});
-  //       bSink.push(2);
-  //       const mySnapshot = at(B.snapshotAt(bSink, occurredFuture));
-  //       mySnapshot.subscribe((res) => (result = res));
-  //       bSink.push(3);
-  //       assert.strictEqual(result, 2);
-  //     });
-  //   });
+  describe("when", () => {
+    it("gives occurred future when behavior is true", () => {
+      let occurred = false;
+      const b = Behavior.of(true);
+      const w = H.when(b);
+      const fut = at(w);
+      fut.subscribe((_) => (occurred = true));
+      assert.strictEqual(occurred, true);
+    });
+    it("future occurs when behavior turns true", () => {
+      let occurred = false;
+      const b = sinkBehavior(false);
+      const w = H.when(b);
+      const fut = at(w);
+      fut.subscribe((_) => (occurred = true));
+      assert.strictEqual(occurred, false);
+      b.publish(true);
+      assert.strictEqual(occurred, true);
+    });
+  });
+  describe("snapshotAt", () => {
+    it("snapshots behavior at future occurring in future", () => {
+      let result: number;
+      const bSink = sinkBehavior(1);
+      const futureSink = H.sinkFuture();
+      const mySnapshot = at(H.snapshotAt(bSink, futureSink));
+      mySnapshot.subscribe((res) => (result = res));
+      bSink.publish(2);
+      bSink.publish(3);
+      futureSink.resolve({});
+      bSink.publish(4);
+      assert.strictEqual(result, 3);
+    });
+    it("uses current value when future occurred in the past", () => {
+      let result: number;
+      const bSink = sinkBehavior(1);
+      const occurredFuture = H.Future.of({});
+      bSink.publish(2);
+      const mySnapshot = at(H.snapshotAt(bSink, occurredFuture));
+      mySnapshot.subscribe((res) => (result = res));
+      bSink.publish(3);
+      assert.strictEqual(result, 2);
+    });
+  });
   describe("switchTo", () => {
     it("switches to new behavior", () => {
       const b1 = sinkBehavior(1);
@@ -621,21 +621,21 @@ describe("Behavior and Future", () => {
   });
 });
 describe("Behavior and Stream", () => {
-  //   describe("switcher", () => {
-  //     it("switches to behavior", () => {
-  //       const result: number[] = [];
-  //       const stream = sinkStream<Behavior<number>>();
-  //       const initB = Behavior.of(1);
-  //       const outerSwitcher = switcher(initB, stream);
-  //       const switchingB = at(outerSwitcher);
-  //       switchingB.subscribe((n) => result.push(n));
-  //       const sinkB = sinkBehavior(2);
-  //       stream.push(sinkB);
-  //       sinkB.push(3);
-  //       assert.deepEqual(result, [1, 2, 3]);
-  //       assert.deepEqual(at(at(outerSwitcher)), 1);
-  //     });
-  //   });
+  describe("switcher", () => {
+    it("switches to behavior", () => {
+      const result: number[] = [];
+      const stream = H.sinkStream<Behavior<number>>();
+      const initB = Behavior.of(1);
+      const outerSwitcher = H.switcher(initB, stream);
+      const switchingB = at(outerSwitcher);
+      switchingB.subscribe((n) => result.push(n));
+      const sinkB = sinkBehavior(2);
+      stream.publish(sinkB);
+      sinkB.publish(3);
+      assert.deepEqual(result, [1, 2, 3]);
+      assert.deepEqual(at(at(outerSwitcher)), 1);
+    });
+  });
   describe("stepper", () => {
     it("steps to the last event value", () => {
       const s = H.sinkStream();
@@ -747,42 +747,44 @@ describe("Behavior and Stream", () => {
       assert.deepEqual(cb.args, [[1], [2], [3], [5], [6]]);
     });
   });
-  //   describe("continuous time", () => {
-  //     it("gives time from sample point", () => {
-  //       const [setTime, restore] = mockNow();
-  //       setTime(3);
-  //       const time = at(timeFrom);
-  //       assert.strictEqual(at(time), 0);
-  //       setTime(4);
-  //       assert.strictEqual(at(time), 1);
-  //       setTime(7);
-  //       assert.strictEqual(at(time), 4);
-  //       restore();
-  //     });
-  //     it("gives time since UNIX epoch", () => {
-  //       let beginPull = false;
-  //       let endPull = false;
-  //       let pushed: number[] = [];
-  //       observe(
-  //         (n: number) => pushed.push(n),
-  //         () => {
-  //           beginPull = true;
-  //           return () => {endPull = true}
-  //         },
-  //         time
-  //       );
-  //       assert.strictEqual(beginPull, true);
-  //       const t = at(time);
-  //       const now = Date.now();
-  //       assert(now - 2 <= t && t <= now);
-  //       assert.strictEqual(endPull, false);
-  //     });
-  //     it("has semantic representation", () => {
-  //       const f = time.semantic();
-  //       assert.strictEqual(f(0), 0);
-  //       assert.strictEqual(f(1.3), 1.3);
-  //     });
-  // });
+  describe("continuous time", () => {
+    it("gives time from sample point", () => {
+      const [setTime, restore] = mockNow();
+      setTime(3);
+      const time = at(H.timeFrom);
+      assert.strictEqual(at(time), 0);
+      setTime(4);
+      assert.strictEqual(at(time), 1);
+      setTime(7);
+      assert.strictEqual(at(time), 4);
+      restore();
+    });
+    it("gives time since UNIX epoch", () => {
+      let beginPull = false;
+      let endPull = false;
+      let pushed: number[] = [];
+      observe(
+        (n: number) => pushed.push(n),
+        () => {
+          beginPull = true;
+          return () => {
+            endPull = true;
+          };
+        },
+        H.time
+      );
+      assert.strictEqual(beginPull, true);
+      const t = at(H.time);
+      const now = Date.now();
+      assert(now - 2 <= t && t <= now);
+      assert.strictEqual(endPull, false);
+    });
+    it("has semantic representation", () => {
+      const f = H.time.semantic();
+      assert.strictEqual(f(0), 0);
+      assert.strictEqual(f(1.3), 1.3);
+    });
+  });
   describe("toggle", () => {
     it("has correct initial value", () => {
       const s1 = H.sinkStream();

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -9,7 +9,7 @@ import {
   observe,
   ProducerBehavior,
   producerBehavior,
-  publish,
+  push,
   sinkBehavior,
   integrate,
   moment,
@@ -121,9 +121,9 @@ describe("behavior", () => {
         const mapped = map(double, b);
         const cb = spy();
         mapped.subscribe(cb);
-        publish(1, b);
-        publish(2, b);
-        publish(3, b);
+        push(1, b);
+        push(2, b);
+        push(3, b);
         assert.deepEqual(cb.args, [[0], [2], [4], [6]]);
       });
       it("maps time function", () => {
@@ -186,11 +186,11 @@ describe("behavior", () => {
         const cb = spy();
         applied.subscribe(cb);
         assert.equal(H.at(applied, 1), 4);
-        publish(add(2), fnB);
+        push(add(2), fnB);
         assert.equal(H.at(applied, 2), 5);
-        publish(4, numE);
+        push(4, numE);
         assert.equal(H.at(applied, 3), 6);
-        publish(double, fnB);
+        push(double, fnB);
         assert.equal(H.at(applied, 4), 8);
         assert.deepEqual(cb.args, [[4], [5], [6], [8]]);
       });
@@ -223,11 +223,11 @@ describe("behavior", () => {
         const cb = spy();
         applied.observe(cb, (pull) => {
           pull(1);
-          publish(add(2), fnB);
+          push(add(2), fnB);
           pull(2);
           n = 4;
           pull(3);
-          publish(double, fnB);
+          push(double, fnB);
           pull(4);
           n = 8;
           pull(5);
@@ -245,11 +245,11 @@ describe("behavior", () => {
         const cb = spy();
         lifted.subscribe(cb);
         assert.strictEqual(at(lifted), 2);
-        publish(2, b2);
+        push(2, b2);
         assert.strictEqual(at(lifted), 3);
-        publish(3, b1);
+        push(3, b1);
         assert.strictEqual(at(lifted), 7);
-        publish(3, b3);
+        push(3, b3);
         assert.strictEqual(at(lifted), 9);
         assert.deepEqual(cb.args, [[2], [3], [7], [9]]);
       });

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -479,22 +479,21 @@ describe("behavior", () => {
       nr3.publish(3);
       assert.deepEqual(cb.args, [[0], [9], [11], [6], [7]]);
     });
-    // it("works with placeholders", () => {
-    //   const p = placeholder<number>();
-    //   const b0 = sinkBehavior(3);
-    //   const b1 = sinkBehavior(1);
-    //   const b2 = sinkBehavior(2);
-    //   const derived = moment((at) => {
-    //     return at(b1) + at(p) + at(b2);
-    //   });
-    //   const cb = spy();
-    //   derived.subscribe(cb);
-    //   b1.publish(2, 1);
-    //   p.replaceWith(b0);
-    //   // @ts-ignore
-    //   p.publish(0, 2);
-    //   assert.deepEqual(cb.args, [[7], [4]]);
-    // });
+    it("works with placeholders", () => {
+      const p = placeholder<number>();
+      const b0 = sinkBehavior(3);
+      const b1 = sinkBehavior(1);
+      const b2 = sinkBehavior(2);
+      const derived = moment((at) => {
+        return at(b1) + at(p) + at(b2);
+      });
+      const cb = spy();
+      derived.subscribe(cb);
+      b1.publish(2);
+      p.replaceWith(b0);
+      b0.publish(0);
+      assert.deepEqual(cb.args, [[7], [4]]);
+    });
     it("works with snapshot", () => {
       const b1 = H.sinkBehavior(1);
       const b2 = H.moment((at) => at(b1) * 2);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -56,6 +56,6 @@ export function createTestProducerBehavior<A>(initial: A) {
   const activate = spy();
   const deactivate = spy();
   const producer = new TestProducerBehavior(initial, activate, deactivate);
-  const publish = producer.newValue.bind(producer);
-  return { activate, deactivate, publish, producer };
+  const push = producer.newValue.bind(producer);
+  return { activate, deactivate, push, producer };
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -56,6 +56,6 @@ export function createTestProducerBehavior<A>(initial: A) {
   const activate = spy();
   const deactivate = spy();
   const producer = new TestProducerBehavior(initial, activate, deactivate);
-  const push = producer.push.bind(producer);
-  return { activate, deactivate, push, producer };
+  const publish = producer.newValue.bind(producer);
+  return { activate, deactivate, publish, producer };
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -5,7 +5,7 @@ import { spy } from "sinon";
 import { State, Reactive } from "../src/common";
 import { Behavior, ProducerBehavior } from "../src/behavior";
 
-export function subscribeSpy(b: Reactive<any>): sinon.SinonSpy {
+export function subscribeSpy(b: Reactive<any, any>): sinon.SinonSpy {
   const cb = spy();
   b.subscribe(cb);
   return cb;
@@ -31,7 +31,7 @@ export function createTestProducer() {
   const activate = spy();
   const deactivate = spy();
   const producer = new TestProducer(activate, deactivate);
-  const push = producer.push.bind(producer);
+  const push = producer.pushS.bind(producer);
   return { activate, deactivate, push, producer };
 }
 

--- a/test/now.ts
+++ b/test/now.ts
@@ -1,7 +1,10 @@
-import { testStreamFromObject } from "../src";
-import { Behavior, switchTo, when, scan } from "../src/behavior";
-import { Future } from "../src/future";
 import {
+  testStreamFromObject,
+  Behavior,
+  switchTo,
+  when,
+  scan,
+  Future,
   perform,
   Now,
   performStream,
@@ -11,9 +14,11 @@ import {
   runNow,
   sample,
   testNow,
-  loopNow
-} from "../src/now";
-import { Stream, sinkStream } from "../src/stream";
+  loopNow,
+  Stream,
+  sinkStream,
+  sinkFuture
+} from "../src";
 import { assert } from "chai";
 import {
   lift,
@@ -180,7 +185,7 @@ describe("Now", () => {
       });
     });
   });
-  it("handles recursively defined behavior", () => {
+  it.only("handles recursively defined behavior", () => {
     let resolve: (n: number) => void;
     const getNextNr = withEffectsP((n: number) => {
       return new Promise((res) => {
@@ -231,11 +236,11 @@ describe("Now", () => {
       performStream(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.push(1);
+      s.publish(1);
       setTimeout(() => {
-        s.push(2);
+        s.publish(2);
         setTimeout(() => {
-          s.push(3);
+          s.publish(3);
           setTimeout(() => {
             assert.deepEqual(actions, [1, 2, 3]);
             assert.deepEqual(results, [3, 4, 5]);
@@ -257,7 +262,7 @@ describe("Now", () => {
       performStreamLatest(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.push(60);
+      s.publish(60);
       setTimeout(() => {
         assert.deepEqual(results, [60]);
         done();
@@ -277,9 +282,9 @@ describe("Now", () => {
       performStreamLatest(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.push(0);
-      s.push(1);
-      s.push(2);
+      s.publish(0);
+      s.publish(1);
+      s.publish(2);
       resolves[1](1);
       resolves[2](2);
       resolves[0](0);
@@ -301,7 +306,7 @@ describe("Now", () => {
       performStreamOrdered(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.push(60);
+      s.publish(60);
       setTimeout(() => {
         assert.deepEqual(results, [60]);
         done();
@@ -321,12 +326,12 @@ describe("Now", () => {
       performStreamOrdered(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.push(0);
-      s.push(1);
-      s.push(2);
-      s.push(3);
-      s.push(4);
-      s.push(5);
+      s.publish(0);
+      s.publish(1);
+      s.publish(2);
+      s.publish(3);
+      s.publish(4);
+      s.publish(5);
       resolves[3](3);
       resolves[1](1);
       resolves[0]("zero");
@@ -349,9 +354,9 @@ describe("Now", () => {
       performStreamOrdered(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.push(60);
-      s.push(undefined);
-      s.push(20);
+      s.publish(60);
+      s.publish(undefined);
+      s.publish(20);
       setTimeout(() => {
         assert.deepEqual(results, [60, undefined, 20]);
         done();
@@ -368,9 +373,9 @@ describe("Now", () => {
         return Now.of({ stream: s });
       });
       now.run();
-      s.push("a");
-      s.push("b");
-      s.push("c");
+      s.publish("a");
+      s.publish("b");
+      s.publish("c");
 
       assert.deepEqual(result, ["a", "b", "c"]);
     });
@@ -384,9 +389,9 @@ describe("Now", () => {
       });
       const { stream } = now.run();
       stream.subscribe((a) => result.push(a));
-      s.push("a");
-      s.push("b");
-      s.push("c");
+      s.publish("a");
+      s.publish("b");
+      s.publish("c");
 
       assert.deepEqual(result, ["a", "b", "c"]);
     });

--- a/test/now.ts
+++ b/test/now.ts
@@ -17,12 +17,11 @@ import {
   loopNow,
   Stream,
   sinkStream,
-  sinkFuture
+  SinkStream
 } from "../src";
 import { assert } from "chai";
 import {
   lift,
-  Either,
   callP,
   IO,
   withEffects,
@@ -236,11 +235,11 @@ describe("Now", () => {
       performStream(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.publish(1);
+      s.push(1);
       setTimeout(() => {
-        s.publish(2);
+        s.push(2);
         setTimeout(() => {
-          s.publish(3);
+          s.push(3);
           setTimeout(() => {
             assert.deepEqual(actions, [1, 2, 3]);
             assert.deepEqual(results, [3, 4, 5]);
@@ -262,7 +261,7 @@ describe("Now", () => {
       performStreamLatest(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.publish(60);
+      s.push(60);
       setTimeout(() => {
         assert.deepEqual(results, [60]);
         done();
@@ -282,9 +281,9 @@ describe("Now", () => {
       performStreamLatest(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.publish(0);
-      s.publish(1);
-      s.publish(2);
+      s.push(0);
+      s.push(1);
+      s.push(2);
       resolves[1](1);
       resolves[2](2);
       resolves[0](0);
@@ -306,7 +305,7 @@ describe("Now", () => {
       performStreamOrdered(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.publish(60);
+      s.push(60);
       setTimeout(() => {
         assert.deepEqual(results, [60]);
         done();
@@ -326,12 +325,12 @@ describe("Now", () => {
       performStreamOrdered(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.publish(0);
-      s.publish(1);
-      s.publish(2);
-      s.publish(3);
-      s.publish(4);
-      s.publish(5);
+      s.push(0);
+      s.push(1);
+      s.push(2);
+      s.push(3);
+      s.push(4);
+      s.push(5);
       resolves[3](3);
       resolves[1](1);
       resolves[0]("zero");
@@ -354,9 +353,9 @@ describe("Now", () => {
       performStreamOrdered(mappedS)
         .run()
         .subscribe((n) => results.push(n));
-      s.publish(60);
-      s.publish(undefined);
-      s.publish(20);
+      s.push(60);
+      s.push(undefined);
+      s.push(20);
       setTimeout(() => {
         assert.deepEqual(results, [60, undefined, 20]);
         done();
@@ -366,22 +365,22 @@ describe("Now", () => {
   describe("loopNow", () => {
     it("should loop the reactives", () => {
       let result = [];
-      let s;
+      let s: SinkStream<string>;
       const now = loopNow(({ stream }) => {
         stream.subscribe((a) => result.push(a));
         s = sinkStream();
         return Now.of({ stream: s });
       });
       now.run();
-      s.publish("a");
-      s.publish("b");
-      s.publish("c");
+      s.push("a");
+      s.push("b");
+      s.push("c");
 
       assert.deepEqual(result, ["a", "b", "c"]);
     });
     it("should return the reactives", () => {
       let result = [];
-      let s;
+      let s: SinkStream<string>;
       const now = loopNow(({ stream }) => {
         stream.subscribe((a) => a);
         s = sinkStream();
@@ -389,9 +388,9 @@ describe("Now", () => {
       });
       const { stream } = now.run();
       stream.subscribe((a) => result.push(a));
-      s.publish("a");
-      s.publish("b");
-      s.publish("c");
+      s.push("a");
+      s.push("b");
+      s.push("c");
 
       assert.deepEqual(result, ["a", "b", "c"]);
     });

--- a/test/now.ts
+++ b/test/now.ts
@@ -185,7 +185,7 @@ describe("Now", () => {
       });
     });
   });
-  it.only("handles recursively defined behavior", () => {
+  it("handles recursively defined behavior", () => {
     let resolve: (n: number) => void;
     const getNextNr = withEffectsP((n: number) => {
       return new Promise((res) => {
@@ -194,9 +194,9 @@ describe("Now", () => {
     });
     function loop(n: number): Now<Behavior<number>> {
       return go(function*() {
-        const e = yield perform(getNextNr(1));
-        const e1 = yield plan(e.map(loop));
-        return switchTo(Behavior.of(n), e1);
+        const nextNumber = yield perform(getNextNr(1));
+        const future = yield plan(nextNumber.map(loop));
+        return switchTo(Behavior.of(n), future);
       });
     }
     function main(): Now<Future<number>> {

--- a/test/placeholder.ts
+++ b/test/placeholder.ts
@@ -11,7 +11,7 @@ import {
   fromFunction,
   sinkBehavior,
   ap,
-  publish,
+  push,
   debounce,
   delay,
   isStream,
@@ -97,13 +97,13 @@ describe("placeholder", () => {
       const callback = subscribeSpy(shot);
       pB.replaceWith(producer);
       assert.isTrue(activate.calledOnce);
-      publish("a", s);
-      publish("b", s);
+      s.push("a");
+      s.push("b");
       push(1);
-      publish("c", s);
-      publish("d", s);
+      s.push("c");
+      s.push("d");
       push(4);
-      publish("e", s);
+      s.push("e");
       assert.deepEqual(callback.args, [[0], [0], [1], [1], [4]]);
     });
     it("adds puller to the behavior it has been replaced with", () => {

--- a/test/placeholder.ts
+++ b/test/placeholder.ts
@@ -18,7 +18,7 @@ import {
   sinkStream,
   snapshot,
   throttle
-} from "../src/index";
+} from "../src";
 
 import { createTestProducerBehavior } from "./helpers";
 

--- a/test/placeholder.ts
+++ b/test/placeholder.ts
@@ -90,9 +90,7 @@ describe("placeholder", () => {
       b.replaceWith(Behavior.of(3));
     });
     it("should work with consumers that only wants to pull", () => {
-      const { activate, publish: push, producer } = createTestProducerBehavior(
-        0
-      );
+      const { activate, push, producer } = createTestProducerBehavior(0);
       const pB = placeholder();
       const s = sinkStream<string>();
       const shot = snapshot(pB, s);
@@ -109,7 +107,7 @@ describe("placeholder", () => {
       assert.deepEqual(callback.args, [[0], [0], [1], [1], [4]]);
     });
     it("adds puller to the behavior it has been replaced with", () => {
-      const { activate, publish, producer } = createTestProducerBehavior(0);
+      const { activate, push, producer } = createTestProducerBehavior(0);
       const pB = placeholder();
       const s = sinkStream<string>();
       pB.replaceWith(producer);

--- a/test/placeholder.ts
+++ b/test/placeholder.ts
@@ -135,7 +135,7 @@ describe("placeholder", () => {
       const s = sinkStream();
       p.replaceWith(s);
       assert.strictEqual(result, 0);
-      s.publish(1);
+      s.push(1);
       assert.strictEqual(result, 2);
     });
     it("mapTo", () => {
@@ -146,8 +146,8 @@ describe("placeholder", () => {
       const cb = subscribeSpy(mapped);
       p.replaceWith(sink);
       assert.deepEqual(cb.args, []);
-      sink.publish(12);
-      sink.publish(12);
+      sink.push(12);
+      sink.push(12);
       assert.deepEqual(cb.args, [[12], [12]]);
     });
     it("snapshot", () => {
@@ -159,7 +159,7 @@ describe("placeholder", () => {
       const s = sinkStream();
       p.replaceWith(s);
       assert.strictEqual(result, 0);
-      s.publish(1);
+      s.push(1);
       assert.strictEqual(result, 7);
     });
     describe("timing operators", () => {
@@ -178,7 +178,7 @@ describe("placeholder", () => {
         p.subscribe(() => (n = 1));
         const s = sinkStream<number>();
         p.replaceWith(s);
-        s.publish(0);
+        s.push(0);
         assert.strictEqual(n, 1);
         clock.tick(49);
         assert.strictEqual(n, 1);
@@ -194,12 +194,12 @@ describe("placeholder", () => {
         assert.strictEqual(n, 0);
         const s = sinkStream<number>();
         p.replaceWith(s);
-        s.publish(1);
+        s.push(1);
         clock.tick(99);
-        s.publish(2);
+        s.push(2);
         assert.strictEqual(n, 1);
         clock.tick(1);
-        s.publish(3);
+        s.push(3);
         assert.strictEqual(n, 3);
       });
       it("should work with placeholder", () => {
@@ -210,12 +210,12 @@ describe("placeholder", () => {
         const s = sinkStream<number>();
         p.replaceWith(s);
         assert.strictEqual(n, 0);
-        s.publish(1);
+        s.push(1);
         clock.tick(80);
         assert.strictEqual(n, 0);
         clock.tick(30);
         assert.strictEqual(n, 1);
-        s.publish(2);
+        s.push(2);
         assert.strictEqual(n, 1);
         clock.tick(99);
         assert.strictEqual(n, 1);

--- a/test/placeholder.ts
+++ b/test/placeholder.ts
@@ -1,9 +1,9 @@
 import { subscribeSpy } from "./helpers";
-import { spy, useFakeTimers } from "sinon";
+import { useFakeTimers } from "sinon";
 import { assert } from "chai";
 
 import { placeholder } from "../src/placeholder";
-import { State, observe } from "../src/common";
+import { observe } from "../src/common";
 import {
   isBehavior,
   Behavior,
@@ -11,26 +11,12 @@ import {
   fromFunction,
   sinkBehavior,
   ap,
-  map,
   publish,
-  apply,
   debounce,
   delay,
-  empty,
-  filter,
-  filterApply,
   isStream,
-  keepWhen,
-  ProducerStream,
-  scanS,
   sinkStream,
   snapshot,
-  snapshotWith,
-  split,
-  Stream,
-  subscribe,
-  testStreamFromArray,
-  testStreamFromObject,
   throttle
 } from "../src/index";
 
@@ -104,7 +90,9 @@ describe("placeholder", () => {
       b.replaceWith(Behavior.of(3));
     });
     it("should work with consumers that only wants to pull", () => {
-      const { activate, push, producer } = createTestProducerBehavior(0);
+      const { activate, publish: push, producer } = createTestProducerBehavior(
+        0
+      );
       const pB = placeholder();
       const s = sinkStream<string>();
       const shot = snapshot(pB, s);
@@ -121,7 +109,7 @@ describe("placeholder", () => {
       assert.deepEqual(callback.args, [[0], [0], [1], [1], [4]]);
     });
     it("adds puller to the behavior it has been replaced with", () => {
-      const { activate, push, producer } = createTestProducerBehavior(0);
+      const { activate, publish, producer } = createTestProducerBehavior(0);
       const pB = placeholder();
       const s = sinkStream<string>();
       pB.replaceWith(producer);

--- a/test/placeholder.ts
+++ b/test/placeholder.ts
@@ -147,7 +147,7 @@ describe("placeholder", () => {
       const s = sinkStream();
       p.replaceWith(s);
       assert.strictEqual(result, 0);
-      s.push(1);
+      s.publish(1);
       assert.strictEqual(result, 2);
     });
     it("mapTo", () => {
@@ -158,8 +158,8 @@ describe("placeholder", () => {
       const cb = subscribeSpy(mapped);
       p.replaceWith(sink);
       assert.deepEqual(cb.args, []);
-      sink.push(12);
-      sink.push(12);
+      sink.publish(12);
+      sink.publish(12);
       assert.deepEqual(cb.args, [[12], [12]]);
     });
     it("snapshot", () => {
@@ -171,7 +171,7 @@ describe("placeholder", () => {
       const s = sinkStream();
       p.replaceWith(s);
       assert.strictEqual(result, 0);
-      s.push(1);
+      s.publish(1);
       assert.strictEqual(result, 7);
     });
     describe("timing operators", () => {
@@ -190,7 +190,7 @@ describe("placeholder", () => {
         p.subscribe(() => (n = 1));
         const s = sinkStream<number>();
         p.replaceWith(s);
-        s.push(0);
+        s.publish(0);
         assert.strictEqual(n, 1);
         clock.tick(49);
         assert.strictEqual(n, 1);
@@ -206,12 +206,12 @@ describe("placeholder", () => {
         assert.strictEqual(n, 0);
         const s = sinkStream<number>();
         p.replaceWith(s);
-        s.push(1);
+        s.publish(1);
         clock.tick(99);
-        s.push(2);
+        s.publish(2);
         assert.strictEqual(n, 1);
         clock.tick(1);
-        s.push(3);
+        s.publish(3);
         assert.strictEqual(n, 3);
       });
       it("should work with placeholder", () => {
@@ -222,12 +222,12 @@ describe("placeholder", () => {
         const s = sinkStream<number>();
         p.replaceWith(s);
         assert.strictEqual(n, 0);
-        s.push(1);
+        s.publish(1);
         clock.tick(80);
         assert.strictEqual(n, 0);
         clock.tick(30);
         assert.strictEqual(n, 1);
-        s.push(2);
+        s.publish(2);
         assert.strictEqual(n, 1);
         clock.tick(99);
         assert.strictEqual(n, 1);

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -8,7 +8,7 @@ import {
   sinkBehavior,
   testBehavior,
   testStreamFromArray
-} from "../src/index";
+} from "../src";
 
 import * as H from "../src";
 

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -65,8 +65,8 @@ describe("stream", () => {
       const cb2 = spy();
       s.subscribe(cb1);
       s.subscribe(cb2);
-      s.publish(2);
-      s.publish(3);
+      s.push(2);
+      s.push(3);
       assert.strictEqual(cb1.callCount, 2);
       assert.strictEqual(cb2.callCount, 2);
     });
@@ -77,8 +77,8 @@ describe("stream", () => {
       s.subscribe(cb1);
       const listener = s.subscribe(cb2);
       s.removeListener(listener.node);
-      s.publish(2);
-      s.publish(3);
+      s.push(2);
+      s.push(3);
       assert.strictEqual(cb1.callCount, 2);
       assert.strictEqual(cb2.callCount, 0);
     });
@@ -91,8 +91,8 @@ describe("stream", () => {
       const listener = s.subscribe(cb2);
       s.subscribe(cb3);
       s.removeListener(listener.node);
-      s.publish(2);
-      s.publish(3);
+      s.push(2);
+      s.push(3);
       assert.strictEqual(cb1.callCount, 2);
       assert.strictEqual(cb2.callCount, 0);
       assert.strictEqual(cb3.callCount, 2);
@@ -193,8 +193,8 @@ describe("stream", () => {
       const callback = spy();
       const combinedS = stream2.combine(stream1);
       combinedS.subscribe(callback);
-      stream1.publish(1);
-      stream2.publish("2");
+      stream1.push(1);
+      stream2.push("2");
       assert.deepEqual(callback.args, [[1], ["2"]]);
     });
     it("should combine three streams", () => {
@@ -203,9 +203,9 @@ describe("stream", () => {
       const stream3 = H.sinkStream();
       const combinedS = H.combine(stream1, stream2, stream3);
       const callback = subscribeSpy(combinedS);
-      stream1.publish(1);
-      stream2.publish(2);
-      stream3.publish(3);
+      stream1.push(1);
+      stream2.push(2);
+      stream3.push(3);
       assert.deepEqual(callback.args, [[1], [2], [3]]);
     });
   });
@@ -224,7 +224,7 @@ describe("stream", () => {
       const mappedObs = map(addTwo, obs);
       mappedObs.subscribe(callback);
       for (let i = 0; i < 5; i++) {
-        obs.publish(i);
+        obs.push(i);
       }
       assert.deepEqual(callback.args, [[2], [3], [4], [5], [6]]);
     });
@@ -233,9 +233,9 @@ describe("stream", () => {
       const callback = spy();
       const mapped = stream.mapTo(7);
       mapped.subscribe(callback);
-      stream.publish(1);
-      stream.publish(2);
-      stream.publish(3);
+      stream.push(1);
+      stream.push(2);
+      stream.push(3);
       assert.deepEqual(callback.args, [[7], [7], [7]]);
     });
     it("maps to constant semantically", () => {
@@ -254,16 +254,16 @@ describe("stream", () => {
       const applied = H.apply(fnB, origin);
       const callback = spy();
       applied.subscribe(callback);
-      origin.publish(2);
-      origin.publish(3);
-      fnB.publish((n: number) => 2 * n);
-      origin.publish(4);
-      origin.publish(5);
-      fnB.publish((n: number) => n / 2);
-      origin.publish(4);
-      fnB.publish(Math.sqrt);
-      origin.publish(25);
-      origin.publish(36);
+      origin.push(2);
+      origin.push(3);
+      fnB.push((n: number) => 2 * n);
+      origin.push(4);
+      origin.push(5);
+      fnB.push((n: number) => n / 2);
+      origin.push(4);
+      fnB.push(Math.sqrt);
+      origin.push(25);
+      origin.push(36);
       assert.deepEqual(callback.args, [[4], [9], [8], [10], [2], [5], [6]]);
     });
   });
@@ -283,7 +283,7 @@ describe("stream", () => {
       const filteredObs = H.filter(isEven, sink);
       H.subscribe(callback, filteredObs);
       for (let i = 0; i < 10; i++) {
-        sink.publish(i);
+        sink.push(i);
       }
       assert.deepEqual(callback.args, [[0], [2], [4], [6], [8]]);
     });
@@ -296,10 +296,10 @@ describe("stream", () => {
       const [a, b] = H.split((n) => n % 2 === 0, sink);
       a.subscribe(callbackA);
       b.subscribe(callbackB);
-      sink.publish(1);
-      sink.publish(4);
-      sink.publish(7);
-      sink.publish(10);
+      sink.push(1);
+      sink.push(4);
+      sink.push(7);
+      sink.push(10);
       assert.deepEqual(callbackA.args, [[4], [10]]);
       assert.deepEqual(callbackB.args, [[1], [7]]);
     });
@@ -313,10 +313,10 @@ describe("stream", () => {
       H.subscribe(callback, filtered);
       publish(2, origin);
       publish(3, origin);
-      predB.publish((n: number) => n % 3 === 0);
+      predB.push((n: number) => n % 3 === 0);
       publish(4, origin);
       publish(6, origin);
-      predB.publish((n: number) => n % 4 === 0);
+      predB.push((n: number) => n % 4 === 0);
       publish(6, origin);
       publish(12, origin);
       assert.deepEqual(callback.args, [[2], [6], [12]]);
@@ -385,7 +385,7 @@ describe("stream", () => {
         const delayedS = H.delay(50, s);
         delayedS.subscribe(() => (n = 2));
         s.subscribe(() => (n = 1));
-        s.publish(0);
+        s.push(0);
         assert.strictEqual(n, 1);
         clock.tick(49);
         assert.strictEqual(n, 1);
@@ -400,16 +400,16 @@ describe("stream", () => {
         const throttleS = H.throttle(100, s);
         throttleS.subscribe((v) => (n = v));
         assert.strictEqual(n, 0);
-        s.publish(1);
+        s.push(1);
         assert.strictEqual(n, 1);
         clock.tick(80);
-        s.publish(2);
+        s.push(2);
         assert.strictEqual(n, 1);
         clock.tick(19);
-        s.publish(3);
+        s.push(3);
         assert.strictEqual(n, 1);
         clock.tick(1);
-        s.publish(4);
+        s.push(4);
         assert.strictEqual(n, 4);
       });
     });
@@ -420,12 +420,12 @@ describe("stream", () => {
         const debouncedS = H.debounce(100, s);
         debouncedS.subscribe((v) => (n = v));
         assert.strictEqual(n, 0);
-        s.publish(1);
+        s.push(1);
         clock.tick(80);
         assert.strictEqual(n, 0);
         clock.tick(30);
         assert.strictEqual(n, 1);
-        s.publish(2);
+        s.push(2);
         assert.strictEqual(n, 1);
         clock.tick(99);
         assert.strictEqual(n, 1);
@@ -473,14 +473,14 @@ describe("stream", () => {
       const shot = H.snapshot(mapped, s);
       const callback = spy();
       shot.subscribe(callback);
-      s.publish(undefined);
+      s.push(undefined);
       publish(1);
-      s.publish(undefined);
+      s.push(undefined);
       publish(2);
-      s.publish(undefined);
+      s.push(undefined);
       publish(3);
       publish(4);
-      s.publish(undefined);
+      s.push(undefined);
       assert(activate.calledOnce, "called once");
       assert.deepEqual(callback.args, [[2], [3], [4], [6]]);
     });
@@ -522,26 +522,26 @@ describe("stream", () => {
       const s = H.changes(b);
       const cb = spy();
       H.subscribe(cb, s);
-      b.publish(1);
-      b.publish(2);
-      b.publish(2);
-      b.publish(2);
-      b.publish(3);
+      b.push(1);
+      b.push(2);
+      b.push(2);
+      b.push(2);
+      b.push(3);
       assert.deepEqual(cb.args, [[1], [2], [3]]);
     });
     /*
-        it("gives changes from pulling behavior", () => {
-          let x = 0;
-          const b = fromFunction(() => x);
-          const s = changes(b);
-          const cb = spy();
-          observe
-          x = 1;
-          x = 2;
-          x = 3;
-          assert.deepEqual(cb.args, [[1], [2], [3]]);
-        });
-        */
+    it("gives changes from pulling behavior", () => {
+      let x = 0;
+      const b = fromFunction(() => x);
+      const s = changes(b);
+      const cb = spy();
+      observe
+      x = 1;
+      x = 2;
+      x = 3;
+      assert.deepEqual(cb.args, [[1], [2], [3]]);
+    });
+    */
   });
   it("works", () => {
     function foobar(stream1, stream2) {

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -1,36 +1,13 @@
 import { assert } from "chai";
 import { spy, useFakeTimers } from "sinon";
-import { State } from "../src/common";
 import {
   map,
   publish,
-  // placeholder,
-  // apply,
-  // changes,
-  // debounce,
-  // delay,
-  // empty,
-  // filter,
-  // filterApply,
-  // isStream,
-  // keepWhen,
-  // producerStream,
-  // ProducerStream,
-  // scanS,
   Behavior,
-  ProducerBehavior,
   fromFunction,
   sinkBehavior,
   testBehavior,
-  // sinkStream,
-  // snapshot,
-  // snapshotWith,
-  // split,
-  // subscribe,
   testStreamFromArray
-  // testStreamFromObject,
-  // throttle,
-  // combine
 } from "../src/index";
 
 import * as H from "../src";
@@ -489,55 +466,55 @@ describe("stream", () => {
       publish(4, e);
       assert.deepEqual(callback.args, [[0], [0], [1], [2], [2]]);
     });
-    //     it("activates producer", () => {
-    //       const { activate, push, producer } = createTestProducerBehavior(0);
-    //       const mapped = map(addTwo, producer);
-    //       const s = sinkStream<undefined>();
-    //       const shot = snapshot(mapped, s);
-    //       const callback = spy();
-    //       shot.subscribe(callback);
-    //       s.push(undefined);
-    //       push(1);
-    //       s.push(undefined);
-    //       push(2);
-    //       s.push(undefined);
-    //       push(3);
-    //       push(4);
-    //       s.push(undefined);
-    //       assert(activate.calledOnce, "called once");
-    //       assert.deepEqual(callback.args, [[2], [3], [4], [6]]);
-    //     });
-    //     it("applies function in snapshotWith to pull based Behavior", () => {
-    //       let n = 0;
-    //       const b: Behavior<number> = fromFunction(() => n);
-    //       const e = sinkStream<number>();
-    //       const shot = snapshotWith<number, number, number>(sum, b, e);
-    //       const callback = spy();
-    //       subscribe(callback, shot);
-    //       publish(0, e);
-    //       publish(1, e);
-    //       n = 1;
-    //       publish(2, e);
-    //       n = 2;
-    //       publish(3, e);
-    //       publish(4, e);
-    //       assert.deepEqual(callback.args, [[0], [1], [3], [5], [6]]);
-    //     });
-    //     it("has semantic representation", () => {
-    //       const b = testBehavior((t) => t * t);
-    //       const s = testStreamFromObject({
-    //         1: 1,
-    //         4: 4,
-    //         8: 8
-    //       });
-    //       const shot = snapshot(b, s);
-    //       const expected = testStreamFromObject({
-    //         1: 1,
-    //         4: 16,
-    //         8: 8 * 8
-    //       });
-    //       assert.deepEqual(shot.semantic(), expected.semantic());
-    //     });
+    it("activates producer", () => {
+      const { activate, publish, producer } = createTestProducerBehavior(0);
+      const mapped = map(addTwo, producer);
+      const s = H.sinkStream<undefined>();
+      const shot = H.snapshot(mapped, s);
+      const callback = spy();
+      shot.subscribe(callback);
+      s.publish(undefined);
+      publish(1);
+      s.publish(undefined);
+      publish(2);
+      s.publish(undefined);
+      publish(3);
+      publish(4);
+      s.publish(undefined);
+      assert(activate.calledOnce, "called once");
+      assert.deepEqual(callback.args, [[2], [3], [4], [6]]);
+    });
+    it("applies function in snapshotWith to pull based Behavior", () => {
+      let n = 0;
+      const b: Behavior<number> = fromFunction(() => n);
+      const e = H.sinkStream<number>();
+      const shot = H.snapshotWith<number, number, number>(sum, b, e);
+      const callback = spy();
+      H.subscribe(callback, shot);
+      publish(0, e);
+      publish(1, e);
+      n = 1;
+      publish(2, e);
+      n = 2;
+      publish(3, e);
+      publish(4, e);
+      assert.deepEqual(callback.args, [[0], [1], [3], [5], [6]]);
+    });
+    it("has semantic representation", () => {
+      const b = testBehavior((t) => t * t);
+      const s = H.testStreamFromObject({
+        1: 1,
+        4: 4,
+        8: 8
+      });
+      const shot = H.snapshot(b, s);
+      const expected = H.testStreamFromObject({
+        1: 1,
+        4: 16,
+        8: 8 * 8
+      });
+      assert.deepEqual(shot.semantic(), expected.semantic());
+    });
   });
   describe("changes", () => {
     it("gives changes from pushing behavior", () => {

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -467,19 +467,19 @@ describe("stream", () => {
       assert.deepEqual(callback.args, [[0], [0], [1], [2], [2]]);
     });
     it("activates producer", () => {
-      const { activate, publish, producer } = createTestProducerBehavior(0);
+      const { activate, push, producer } = createTestProducerBehavior(0);
       const mapped = map(addTwo, producer);
       const s = H.sinkStream<undefined>();
       const shot = H.snapshot(mapped, s);
       const callback = spy();
       shot.subscribe(callback);
       s.push(undefined);
-      publish(1);
+      push(1);
       s.push(undefined);
-      publish(2);
+      push(2);
       s.push(undefined);
-      publish(3);
-      publish(4);
+      push(3);
+      push(4);
       s.push(undefined);
       assert(activate.calledOnce, "called once");
       assert.deepEqual(callback.args, [[2], [3], [4], [6]]);

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 import { spy, useFakeTimers } from "sinon";
 import {
   map,
-  publish,
+  push,
   Behavior,
   fromFunction,
   sinkBehavior,
@@ -311,14 +311,14 @@ describe("stream", () => {
       const filtered = H.filterApply(predB, origin);
       const callback = spy();
       H.subscribe(callback, filtered);
-      publish(2, origin);
-      publish(3, origin);
+      push(2, origin);
+      push(3, origin);
       predB.push((n: number) => n % 3 === 0);
-      publish(4, origin);
-      publish(6, origin);
+      push(4, origin);
+      push(6, origin);
       predB.push((n: number) => n % 4 === 0);
-      publish(6, origin);
-      publish(12, origin);
+      push(6, origin);
+      push(12, origin);
       assert.deepEqual(callback.args, [[2], [6], [12]]);
     });
   });
@@ -331,7 +331,7 @@ describe("stream", () => {
       const currentSumE = H.scanS(sumF, 0, eventS).at();
       H.subscribe(callback, currentSumE);
       for (let i = 0; i < 10; i++) {
-        publish(i, eventS);
+        push(i, eventS);
       }
       assert.deepEqual(callback.args, [
         [0],
@@ -356,17 +356,17 @@ describe("stream", () => {
       const filtered = H.keepWhen(origin, bool);
       const callback = spy();
       H.subscribe(callback, filtered);
-      publish(0, origin);
-      publish(1, origin);
+      push(0, origin);
+      push(1, origin);
       flag = false;
-      publish(2, origin);
-      publish(3, origin);
+      push(2, origin);
+      push(3, origin);
       flag = true;
-      publish(4, origin);
+      push(4, origin);
       flag = false;
-      publish(5, origin);
+      push(5, origin);
       flag = true;
-      publish(6, origin);
+      push(6, origin);
       assert.deepEqual(callback.args, [[0], [1], [4], [6]]);
     });
   });
@@ -442,13 +442,13 @@ describe("stream", () => {
       const shot = H.snapshot<number>(b, e);
       const callback = spy();
       H.subscribe(callback, shot);
-      publish(0, e);
-      publish(1, e);
+      push(0, e);
+      push(1, e);
       n = 1;
-      publish(2, e);
+      push(2, e);
       n = 2;
-      publish(3, e);
-      publish(4, e);
+      push(3, e);
+      push(4, e);
       assert.deepEqual(callback.args, [[0], [0], [1], [2], [2]]);
     });
     it("snapshots push based Behavior", () => {
@@ -457,13 +457,13 @@ describe("stream", () => {
       const shot = H.snapshot<number>(b, e);
       const callback = spy();
       H.subscribe(callback, shot);
-      publish(0, e);
-      publish(1, e);
-      publish(1, b);
-      publish(2, e);
-      publish(2, b);
-      publish(3, e);
-      publish(4, e);
+      push(0, e);
+      push(1, e);
+      push(1, b);
+      push(2, e);
+      push(2, b);
+      push(3, e);
+      push(4, e);
       assert.deepEqual(callback.args, [[0], [0], [1], [2], [2]]);
     });
     it("activates producer", () => {
@@ -491,13 +491,13 @@ describe("stream", () => {
       const shot = H.snapshotWith<number, number, number>(sum, b, e);
       const callback = spy();
       H.subscribe(callback, shot);
-      publish(0, e);
-      publish(1, e);
+      push(0, e);
+      push(1, e);
       n = 1;
-      publish(2, e);
+      push(2, e);
       n = 2;
-      publish(3, e);
-      publish(4, e);
+      push(3, e);
+      push(4, e);
       assert.deepEqual(callback.args, [[0], [1], [3], [5], [6]]);
     });
     it("has semantic representation", () => {


### PR DESCRIPTION
By using timestamps, we can efficiently cache values and make sure only to make recomputations when necessary.