### PR TITLE
Throughout now computation sample always pulls with the same timestamp

### DIFF
--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -412,11 +412,13 @@ export class FunctionBehavior<A> extends ActiveBehavior<A> {
     super();
     this.state = State.OnlyPull;
   }
-  pull(t) {
-    this.refresh(t);
-    this.pulledAt = t;
+  pull(t: Time): void {
+    if (this.pulledAt !== t) {
+      this.refresh(t);
+      this.pulledAt = t;
+    }
   }
-  update(t): A {
+  update(t: Time): A {
     return this.fn();
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -53,7 +53,7 @@ export class PushOnlyObserver<A> implements BListener, SListener<A> {
   pushB(t: number): void {
     this.callback((this.source as any).last);
   }
-  pushS(t: number, value: A) {
+  pushS(t: number, value: A): void {
     this.callback(value);
   }
   deactivate(): void {

--- a/src/future.ts
+++ b/src/future.ts
@@ -1,5 +1,5 @@
 import { monad, Monad, Semigroup } from "@funkia/jabz";
-import { State, SListener, Parent, BListener } from "./common";
+import { State, SListener, Parent, BListener, Time } from "./common";
 import { Reactive } from "./common";
 import { cons, fromArray, Node } from "./datastructures";
 import { Behavior, FunctionBehavior } from "./behavior";
@@ -24,7 +24,7 @@ export abstract class Future<A> extends Reactive<A, SListener<A>>
   pull(): A {
     throw new Error("Pull not implemented on future");
   }
-  resolve(val: A, t = tick()): void {
+  resolve(val: A, t: Time = tick()): void {
     this.deactivate(true);
     this.value = val;
     this.pushSToChildren(t, val);
@@ -184,10 +184,16 @@ export function sinkFuture<A>(): Future<A> {
   return new SinkFuture<A>();
 }
 
-export function fromPromise<A>(p: Promise<A>): Future<A> {
+export function fromPromise<A>(promise: Promise<A>): Future<A> {
   const future = sinkFuture<A>();
-  p.then(future.resolve.bind(future));
+  promise.then(future.resolve.bind(future));
   return future;
+}
+
+export function toPromise<A>(future: Future<A>): Promise<A> {
+  return new Promise((resolve, _reject) => {
+    future.subscribe(resolve);
+  });
 }
 
 /**

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -112,6 +112,18 @@ describe("behavior", () => {
       time = 3;
       assert.equal(H.at(b, 4), 3);
     });
+    it("does not recompute when pulling with same timestamp", () => {
+      let callCount = 0;
+      const b = H.fromFunction(() => {
+        callCount++;
+        return 0;
+      });
+      b.at(0);
+      b.at(0);
+      b.at(1);
+      b.at(1);
+      assert.strictEqual(callCount, 2);
+    });
   });
   describe("functor", () => {
     describe("map", () => {


### PR DESCRIPTION
This PR makes four changes

* `FunctionBehavior` previously forgot to consider `pulledAt`. It nows compares `pulledAt` with the current time and returns it's current value without recomputation if they are equal.
* Adds a new function `toPromise: <A>(future: Future<A>) => Promise<A>` that converts a promise to a future.
* Changes the behavior of `runNow` from `runNow<A>(now: Now<Future<A>>): Promise<A>` into `runNow<A>(now: Now<A>, time: Time = tick()): A`. I.e. `runNow` no longer requires the now computation to return a future and it doesn't create a promise. The old behavior can now be achieved by combining `runNow` with `toPromise`.
* Running a now computation now takes a timestamp. This timestamp is passed along through the computation. `sample` uses this to always pull behaviors with the same timestamp. This is both more efficient and it improves the abstraction that a now computation happens in an infinitely short instant.