### PR TITLE
Refactor fewer ticks

### DIFF
--- a/src/animation.ts
+++ b/src/animation.ts
@@ -30,7 +30,7 @@ export function transitionBehavior(
   triggerStream: Stream<number>,
   timeB: Behavior<number> = time
 ): Behavior<Behavior<number>> {
-  return go(function*() {
+  return go(function*(): any {
     const rangeValueB: Behavior<Range> = yield scan(
       (newV, prev) => ({ from: prev.to, to: newV }),
       { from: initial, to: initial },

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -4,7 +4,7 @@ import { State, Reactive, Time, BListener, Parent, SListener } from "./common";
 import { Future, BehaviorFuture } from "./future";
 import * as F from "./future";
 import { Stream } from "./stream";
-import { tick } from "./clock";
+import { tick, getTime } from "./clock";
 
 /**
  * A behavior is a value that changes over time. Conceptually it can
@@ -390,7 +390,7 @@ export class ConstantBehavior<A> extends ActiveBehavior<A> {
   constructor(public last: A) {
     super();
     this.state = State.Push;
-    this.changedAt = tick();
+    this.changedAt = getTime();
   }
   update(_t: number): A {
     return this.last;

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -408,7 +408,7 @@ export class ConstantBehavior<A> extends ActiveBehavior<A> {
 
 /** @private */
 export class FunctionBehavior<A> extends ActiveBehavior<A> {
-  constructor(private fn: () => A) {
+  constructor(private f: (t: Time) => A) {
     super();
     this.state = State.OnlyPull;
   }
@@ -419,12 +419,12 @@ export class FunctionBehavior<A> extends ActiveBehavior<A> {
     }
   }
   update(t: Time): A {
-    return this.fn();
+    return this.f(t);
   }
 }
 
-export function fromFunction<B>(fn: () => B): Behavior<B> {
-  return new FunctionBehavior(fn);
+export function fromFunction<B>(f: (t: Time) => B): Behavior<B> {
+  return new FunctionBehavior(f);
 }
 
 /** @private */
@@ -434,10 +434,10 @@ class SwitcherBehavior<A> extends ActiveBehavior<A>
   private nNode: Node<this> = new Node(this);
   constructor(
     private b: Behavior<A>,
-    next: Future<Behavior<A>> | Stream<Behavior<A>>
+    next: Future<Behavior<A>> | Stream<Behavior<A>>,
+    t: Time
   ) {
     super();
-    const t = tick();
     this.parents = cons(b);
     b.addListener(this.bNode, t);
     this.state = b.state;
@@ -480,14 +480,14 @@ export function switchTo<A>(
   init: Behavior<A>,
   next: Future<Behavior<A>>
 ): Behavior<A> {
-  return new SwitcherBehavior(init, next);
+  return new SwitcherBehavior(init, next, tick());
 }
 
 export function switcher<A>(
   init: Behavior<A>,
   stream: Stream<Behavior<A>>
 ): Behavior<Behavior<A>> {
-  return fromFunction(() => new SwitcherBehavior(init, stream));
+  return fromFunction((t) => new SwitcherBehavior(init, stream, t));
 }
 
 export function freezeTo<A>(

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -527,10 +527,10 @@ class ActiveScanBehavior<A, B> extends ActiveBehavior<B>
   constructor(
     private f: (a: A, b: B) => B,
     public last: B,
-    private parent: Stream<A>
+    private parent: Stream<A>,
+    t: Time
   ) {
     super();
-    const t = tick();
     this.state = State.Push;
     parent.addListener(this.node, t);
   }
@@ -553,7 +553,7 @@ class ActiveScanBehavior<A, B> extends ActiveBehavior<B>
 
 class ScanBehavior<A, B> extends StatefulBehavior<Behavior<B>> {
   update(t: number): Behavior<B> {
-    return new ActiveScanBehavior(this.a, this.b, this.c);
+    return new ActiveScanBehavior(this.a, this.b, this.c, t);
   }
   pull(t: Time): void {
     this.last = this.update(t);

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -625,6 +625,7 @@ export type SampleAt = <B>(b: Behavior<B>) => B;
 
 class MomentBehavior<A> extends Behavior<A> {
   private sampleBound: SampleAt;
+  private currentSampleTime: Time;
   constructor(private f: (at: SampleAt) => A) {
     super();
     this.sampleBound = (b) => this.sample(b);
@@ -654,6 +655,7 @@ class MomentBehavior<A> extends Behavior<A> {
     }
   }
   update(t: number) {
+    this.currentSampleTime = t;
     if (this.listenerNodes !== undefined) {
       for (const { node, parent } of this.listenerNodes) {
         parent.removeListener(node);
@@ -666,9 +668,8 @@ class MomentBehavior<A> extends Behavior<A> {
   sample<B>(b: Behavior<B>): B {
     const node = new Node(this);
     this.listenerNodes = cons({ node, parent: b }, this.listenerNodes);
-    const t = tick();
-    b.addListener(node, t);
-    b.pull(t);
+    b.addListener(node, this.currentSampleTime);
+    b.pull(this.currentSampleTime);
     this.parents = cons(b, this.parents);
     return b.last;
   }

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -385,13 +385,6 @@ export abstract class ActiveBehavior<A> extends Behavior<A> {
   deactivate(): void {}
 }
 
-export abstract class StatefulBehavior<A> extends ActiveBehavior<A> {
-  constructor(protected a: any, protected b?: any, protected c?: any) {
-    super();
-    this.state = State.OnlyPull;
-  }
-}
-
 export class ConstantBehavior<A> extends ActiveBehavior<A> {
   constructor(public last: A) {
     super();
@@ -410,7 +403,7 @@ export class ConstantBehavior<A> extends ActiveBehavior<A> {
 export class FunctionBehavior<A> extends ActiveBehavior<A> {
   constructor(private f: (t: Time) => A) {
     super();
-    this.state = State.OnlyPull;
+    this.state = State.Pull;
   }
   pull(t: Time): void {
     if (this.pulledAt !== t) {
@@ -551,9 +544,13 @@ class ActiveScanBehavior<A, B> extends ActiveBehavior<B>
   }
 }
 
-class ScanBehavior<A, B> extends StatefulBehavior<Behavior<B>> {
+class ScanBehavior<A, B> extends ActiveBehavior<Behavior<B>> {
+  constructor(private f: any, private b: any, private c: any) {
+    super();
+    this.state = State.Pull;
+  }
   update(t: number): Behavior<B> {
-    return new ActiveScanBehavior(this.a, this.b, this.c, t);
+    return new ActiveScanBehavior(this.f, this.b, this.c, t);
   }
   pull(t: Time): void {
     this.last = this.update(t);
@@ -567,7 +564,7 @@ class ScanBehavior<A, B> extends StatefulBehavior<Behavior<B>> {
         stream
           .filter(({ time }) => t1 <= time && time <= t2)
           .map((o) => o.value)
-          .reduce((acc, cur) => this.a(cur, acc), this.b)
+          .reduce((acc, cur) => this.f(cur, acc), this.b)
       );
   }
 }

--- a/src/clock.ts
+++ b/src/clock.ts
@@ -1,5 +1,5 @@
 let time = -1;
 
-export function tick() {
+export function tick(): number {
   return ++time;
 }

--- a/src/clock.ts
+++ b/src/clock.ts
@@ -3,3 +3,7 @@ let time = -1;
 export function tick(): number {
   return ++time;
 }
+
+export function getTime(): number {
+  return time;
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -15,9 +15,6 @@ export const enum State {
   Push,
   // Values should be pulled by listeners
   Pull,
-  // Values should be pulled and the reactive will _never_ switch
-  // state to `Push`
-  OnlyPull,
   // Most, but not all, reactives start in this state
   Inactive,
   // The reactive value will never update again
@@ -132,17 +129,14 @@ export class CbObserver<A> implements BListener, SListener<A> {
     private source: Parent<Child>
   ) {
     source.addListener(this.node, tick());
-    if (source.state === State.Pull || source.state === State.OnlyPull) {
+    if (source.state === State.Pull) {
       this.endPulling = handlePulling(this.pull.bind(this));
     } else if (isBehavior(source) && source.state === State.Push) {
       callback(source.last);
     }
   }
   pull(t: number = tick()): void {
-    if (
-      isBehavior(this.source) &&
-      (this.source.state === State.Pull || this.source.state === State.OnlyPull)
-    ) {
+    if (isBehavior(this.source) && this.source.state === State.Pull) {
       this.source.pull(t);
       this.callback(this.source.last);
     }
@@ -154,7 +148,7 @@ export class CbObserver<A> implements BListener, SListener<A> {
     this.callback(value);
   }
   changeStateDown(state: State): void {
-    if (state === State.Pull || state === State.OnlyPull) {
+    if (state === State.Pull) {
       this.endPulling = this.handlePulling(this.pull.bind(this));
     } else if (this.endPulling !== undefined) {
       // We where pulling before but are no longer pulling

--- a/src/common.ts
+++ b/src/common.ts
@@ -43,7 +43,7 @@ export interface SListener<A> extends Child {
 }
 
 export class PushOnlyObserver<A> implements BListener, SListener<A> {
-  node = new Node(this);
+  node: Node<this> = new Node(this);
   constructor(private callback: (a: A) => void, private source: Parent<Child>) {
     source.addListener(this.node, tick());
     if (isBehavior(source) && source.state === State.Push) {
@@ -95,7 +95,7 @@ export abstract class Reactive<A, C extends Child> implements Child {
       child.changeStateDown(state);
     }
   }
-  subscribe(callback: (a: A) => void) {
+  subscribe(callback: (a: A) => void): PushOnlyObserver<A> {
     return new PushOnlyObserver(callback, this);
   }
   observe(push: (a: A) => void, handlePulling: PullHandler): CbObserver<A> {
@@ -113,7 +113,7 @@ export abstract class Reactive<A, C extends Child> implements Child {
       }
     }
   }
-  deactivate(done = false): void {
+  deactivate(done: Boolean = false): void {
     if (this.listenerNodes !== undefined) {
       for (const { node, parent } of this.listenerNodes) {
         parent.removeListener(node);

--- a/src/future.ts
+++ b/src/future.ts
@@ -29,7 +29,7 @@ export abstract class Future<A> extends Reactive<A, SListener<A>>
     this.value = val;
     this.pushSToChildren(t, val);
   }
-  pushSToChildren(t: number, val: A) {
+  pushSToChildren(t: number, val: A): void {
     for (const child of this.children) {
       child.pushS(t, val);
     }
@@ -149,7 +149,7 @@ class LiftFuture<A> extends Future<A> {
 
 class ChainFuture<A, B> extends Future<B> implements SListener<A> {
   private parentOccurred: boolean = false;
-  private node = new Node(this);
+  private node: Node<this> = new Node(this);
   constructor(private f: (a: A) => Future<B>, private parent: Future<A>) {
     super();
     this.parents = cons(parent);
@@ -203,7 +203,7 @@ export function toPromise<A>(future: Future<A>): Promise<A> {
  * @private
  */
 export class BehaviorFuture<A> extends SinkFuture<A> implements BListener {
-  node = new Node(this);
+  node: Node<this> = new Node(this);
   constructor(private b: Behavior<A>) {
     super();
     b.addListener(this.node, tick());

--- a/src/now.ts
+++ b/src/now.ts
@@ -107,7 +107,7 @@ export function performStream<A>(s: Stream<IO<A>>): Now<Stream<A>> {
 
 class PerformIOStreamLatest<A> extends ActiveStream<A>
   implements SListener<IO<A>> {
-  private node = new Node(this);
+  private node: Node<this> = new Node(this);
   constructor(s: Stream<IO<A>>) {
     super();
     s.addListener(this.node, tick());
@@ -148,7 +148,7 @@ export function performStreamLatest<A>(s: Stream<IO<A>>): Now<Stream<A>> {
 }
 
 class PerformIOStreamOrdered<A> extends ActiveStream<A> {
-  private node = new Node(this);
+  private node: Node<this> = new Node(this);
   constructor(s: Stream<IO<A>>) {
     super();
     s.addListener(this.node, tick());

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -14,7 +14,7 @@ class SamplePlaceholderError {
 
 export class Placeholder<A> extends Behavior<A> {
   source: Reactive<A, SListener<A> | SListener<A> | BListener>;
-  private node = new Node(this);
+  private node: Node<this> = new Node(this);
   replaceWith(
     parent: Reactive<A, SListener<A> | SListener<A> | BListener>
   ): void {
@@ -57,7 +57,7 @@ export class Placeholder<A> extends Behavior<A> {
       this.changeStateDown(this.state);
     }
   }
-  deactivate(done = false): void {
+  deactivate(done: Boolean = false): void {
     this.state = State.Inactive;
     if (this.source !== undefined) {
       this.source.removeListener(this.node);
@@ -72,7 +72,7 @@ export class Placeholder<A> extends Behavior<A> {
 }
 
 class MapPlaceholder<A, B> extends MapBehavior<A, B> {
-  pushS(t: number, a: A) {
+  pushS(t: number, a: A): void {
     // @ts-ignore
     this.pushSToChildren(t, this.f(a));
   }
@@ -80,10 +80,10 @@ class MapPlaceholder<A, B> extends MapBehavior<A, B> {
 
 class MapToPlaceholder<A, B> extends MapToStream<A, B> {
   last: B;
-  update() {
+  update(): B {
     return (<any>this).b;
   }
-  pull() {}
+  pull(): void {}
 }
 
 function install(target: Function, source: Function): void {

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -1,5 +1,5 @@
 import { Reactive, State, SListener, BListener } from "./common";
-import { Behavior, isBehavior, MapBehavior } from "./behavior";
+import { Behavior, isBehavior, MapBehavior, pushToChildren } from "./behavior";
 import { Node, cons } from "./datastructures";
 import { Stream, MapToStream } from "./stream";
 import { tick } from "./clock";
@@ -24,7 +24,7 @@ export class Placeholder<A> extends Behavior<A> {
       const t = tick();
       this.activate(t);
       if (isBehavior(parent) && this.state === State.Push) {
-        this.pushToChildren(t);
+        pushToChildren(t, this);
       }
     }
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -48,7 +48,7 @@ export abstract class Stream<A> extends Reactive<A, SListener<A>>
     throw new Error("The stream does not have a semantic representation");
   }
   abstract pushS(t: number, value: any): void;
-  pushSToChildren(t: number, value: any) {
+  pushSToChildren(t: number, value: any): void {
     for (const child of this.children) {
       child.pushS(t, value);
     }
@@ -168,7 +168,7 @@ class EmptyStream extends ActiveStream<any> {
 export const empty: Stream<any> = new EmptyStream();
 
 class ScanStream<A, B> extends ActiveStream<B> {
-  private node = new Node(this);
+  private node: Node<this> = new Node(this);
   constructor(
     private fn: (a: A, b: B) => B,
     public last: B,
@@ -207,8 +207,8 @@ export function scanS<A, B>(
 }
 
 class SwitchBehaviorStream<A> extends Stream<A> implements BListener {
-  private bNode = new Node(this);
-  private sNode = new Node(this);
+  private bNode: Node<this> = new Node(this);
+  private sNode: Node<this> = new Node(this);
   private currentSource: Stream<A>;
   constructor(private b: Behavior<Stream<A>>) {
     super();
@@ -317,7 +317,7 @@ class ProducerStreamFromFunction<A> extends ProducerStream<A> {
     super();
   }
   deactivateFn: () => void;
-  publish(a: A, t: number = tick()) {
+  publish(a: A, t: number = tick()): void {
     this.pushS(t, a);
   }
   activate(): void {
@@ -368,7 +368,7 @@ export function subscribe<A>(fn: (a: A) => void, stream: Stream<A>): void {
 }
 
 class SnapshotStream<B> extends Stream<B> {
-  private node = new Node(this);
+  private node: Node<this> = new Node(this);
   constructor(private behavior: Behavior<B>, private stream: Stream<any>) {
     super();
     this.parents = cons(stream);
@@ -394,7 +394,7 @@ export function snapshot<B>(b: Behavior<B>, s: Stream<any>): Stream<B> {
 }
 
 class SnapshotWithStream<A, B, C> extends Stream<C> {
-  private node = new Node(this);
+  private node: Node<this> = new Node(this);
   constructor(
     private fn: (a: A, b: B) => C,
     private behavior: Behavior<B>,
@@ -432,7 +432,7 @@ export function isStream(s: any): s is Stream<any> {
 }
 
 class PerformCbStream<A, B> extends ActiveStream<B> implements SListener<A> {
-  node = new Node(this);
+  node: Node<this> = new Node(this);
   doneCb = (result: B): void => this.pushSToChildren(tick(), result);
   constructor(
     private cb: (value: A, done: (result: B) => void) => void,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -34,7 +34,7 @@ export abstract class Stream<A> extends Reactive<A, SListener<A>>
     return new FilterStream<A>(this, fn);
   }
   scanS<B>(fn: (a: A, b: B) => B, startingValue: B): Behavior<Stream<B>> {
-    return fromFunction(() => new ScanStream(fn, startingValue, this));
+    return fromFunction((t) => new ScanStream(fn, startingValue, this, t));
   }
   scan<B>(fn: (a: A, b: B) => B, init: B): Behavior<Behavior<B>> {
     return scan(fn, init, this);
@@ -53,10 +53,6 @@ export abstract class Stream<A> extends Reactive<A, SListener<A>>
       child.pushS(t, value);
     }
   }
-  pull(t: number): void {
-    throw new Error("Pull not implemented on stream");
-  }
-  // abstract semantic(): SemanticStream<A>;
 }
 
 export class MapStream<A, B> extends Stream<B> {
@@ -172,11 +168,12 @@ class ScanStream<A, B> extends ActiveStream<B> {
   constructor(
     private fn: (a: A, b: B) => B,
     public last: B,
-    public parent: Stream<A>
+    public parent: Stream<A>,
+    t: Time
   ) {
     super();
     this.parents = cons(parent);
-    parent.addListener(this.node, tick());
+    parent.addListener(this.node, t);
   }
   semantic(): SemanticStream<B> {
     const s = this.parent.semantic();

--- a/src/time.ts
+++ b/src/time.ts
@@ -77,7 +77,7 @@ class TimeFromBehavior extends Behavior<Time> {
     this.startTime = Date.now();
     this.state = State.Pull;
   }
-  pull(t: number) {
+  pull(t: number): void {
     this.last = Date.now() - this.startTime;
   }
   update(t: number): Time {
@@ -121,7 +121,7 @@ class IntegrateBehavior extends Behavior<number> {
     this.last = 0;
     this.parents = cons(parent, cons(time));
   }
-  update(t) {
+  update(t: Time): number {
     const currentPullTime = time.last;
     const deltaSeconds = (currentPullTime - this.lastPullTime) / 1000;
     const value = this.last + deltaSeconds * this.parent.last;

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -88,10 +88,13 @@ describe("behavior", () => {
     it("activates and deactivates", () => {
       const activate = spy();
       const deactivate = spy();
-      const producer = producerBehavior((push) => {
-        activate();
-        return deactivate;
-      }, () => "");
+      const producer = producerBehavior(
+        (push) => {
+          activate();
+          return deactivate;
+        },
+        () => ""
+      );
       const observer = producer.subscribe((a) => a);
       observer.deactivate();
       assert(activate.calledOnce);

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -18,7 +18,8 @@ import {
   sinkFuture,
   freezeTo,
   freezeAt,
-  Stream
+  Stream,
+  time
 } from "../src";
 
 import * as H from "../src";
@@ -514,6 +515,21 @@ describe("behavior", () => {
       const b2 = H.moment((at) => at(b1) * 2);
       const snapped = H.snapshot(b2, H.empty);
       const cb = subscribeSpy(snapped);
+    });
+    it("time doesn't pass inside moment", () => {
+      const b = moment((at) => {
+        const t1 = at(time);
+        while (Date.now() <= t1) {}
+        const t2 = at(time);
+        assert.strictEqual(t1, t2);
+      });
+      b.observe(
+        () => {},
+        (pull) => {
+          pull();
+          return () => {};
+        }
+      );
     });
   });
 });

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -88,13 +88,10 @@ describe("behavior", () => {
     it("activates and deactivates", () => {
       const activate = spy();
       const deactivate = spy();
-      const producer = producerBehavior(
-        (push) => {
-          activate();
-          return deactivate;
-        },
-        () => ""
-      );
+      const producer = producerBehavior((push) => {
+        activate();
+        return deactivate;
+      }, () => "");
       const observer = producer.subscribe((a) => a);
       observer.deactivate();
       assert(activate.calledOnce);


### PR DESCRIPTION
This PR.

* Reduces the amount of `tick()` calls which is better for performance and which in one case fixes a bug related to `moment`.
* Converts `refresh` and `pushToChildren` to functions to make it more explicit that they are never overloaded.
* Fixes some linter bugs