### PR TITLE
Add performMap

### DIFF
--- a/src/now.ts
+++ b/src/now.ts
@@ -79,30 +79,31 @@ export function sample<A>(b: Behavior<A>): Now<A> {
   return new SampleNow(b);
 }
 
-class PerformNow<A> extends Now<Future<A>> {
-  constructor(private comp: IO<A>) {
+class PerformNow<A> extends Now<A> {
+  constructor(private cb: () => A) {
     super();
   }
-  run(): Future<A> {
-    return fromPromise(runIO(this.comp));
+  run(): A {
+    return this.cb();
   }
 }
 
-export function perform<A>(comp: IO<A>): Now<Future<A>> {
-  return new PerformNow(comp);
+/**
+ * Create a now-computation that executes the effectful computation `cb` when it
+ * is run.
+ */
+export function perform<A>(cb: () => A): Now<A> {
+  return new PerformNow(cb);
 }
 
-class PerformStreamNow<A> extends Now<Stream<A>> {
-  constructor(private s: Stream<IO<A>>) {
-    super();
-  }
-  run(): Stream<A> {
-    return mapCbStream<IO<A>, A>((io, cb) => runIO(io).then(cb), this.s);
-  }
+export function performIO<A>(comp: IO<A>): Now<Future<A>> {
+  return perform(() => fromPromise(runIO(comp)));
 }
 
 export function performStream<A>(s: Stream<IO<A>>): Now<Stream<A>> {
-  return new PerformStreamNow(s);
+  return perform(() =>
+    mapCbStream<IO<A>, A>((io, cb) => runIO(io).then(cb), s)
+  );
 }
 
 class PerformMapNow<A, B> extends Now<Stream<B> | Future<B>> {
@@ -125,7 +126,12 @@ export function performMap<A, B>(
   cb: (a: A) => B,
   s: Stream<A> | Future<A>
 ): Now<Stream<B> | Future<B>> {
-  return new PerformMapNow(cb, s);
+  return perform(
+    () =>
+      isStream(s)
+        ? mapCbStream((value, done) => done(cb(value)), s)
+        : mapCbFuture((value, done) => done(cb(value)), s)
+  );
 }
 
 class PerformIOStreamLatest<A> extends ActiveStream<A>
@@ -157,17 +163,8 @@ class PerformIOStreamLatest<A> extends ActiveStream<A>
   }
 }
 
-class PerformStreamNowLatest<A> extends Now<Stream<A>> {
-  constructor(private s: Stream<IO<A>>) {
-    super();
-  }
-  run(): Stream<A> {
-    return new PerformIOStreamLatest(this.s);
-  }
-}
-
 export function performStreamLatest<A>(s: Stream<IO<A>>): Now<Stream<A>> {
-  return new PerformStreamNowLatest(s);
+  return perform(() => new PerformIOStreamLatest(s));
 }
 
 class PerformIOStreamOrdered<A> extends ActiveStream<A> {
@@ -200,17 +197,8 @@ class PerformIOStreamOrdered<A> extends ActiveStream<A> {
   }
 }
 
-class PerformStreamNowOrdered<A> extends Now<Stream<A>> {
-  constructor(private s: Stream<IO<A>>) {
-    super();
-  }
-  run(): Stream<A> {
-    return new PerformIOStreamOrdered(this.s);
-  }
-}
-
 export function performStreamOrdered<A>(s: Stream<IO<A>>): Now<Stream<A>> {
-  return new PerformStreamNowOrdered(s);
+  return perform(() => new PerformIOStreamOrdered(s));
 }
 
 class PlanNow<A> extends Now<Future<A>> {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -449,7 +449,7 @@ class PerformCbStream<A, B> extends ActiveStream<B> implements SListener<A> {
  * This function is intended to be a low-level function used as the
  * basis for other operators.
  */
-export function performCb<A, B>(
+export function mapCbStream<A, B>(
   cb: (value: A, done: (result: B) => void) => void,
   s: Stream<A>
 ): Stream<B> {

--- a/test/future.ts
+++ b/test/future.ts
@@ -1,7 +1,14 @@
 import { assert } from "chai";
 import { lift } from "@funkia/jabz";
-import { Future, sinkFuture, fromPromise, nextOccurence } from "../src/future";
+import {
+  Future,
+  sinkFuture,
+  fromPromise,
+  nextOccurence,
+  mapCbFuture
+} from "../src/future";
 import { SinkStream } from "../src";
+import { spy } from "sinon";
 
 describe("Future", () => {
   describe("sink", () => {
@@ -168,6 +175,25 @@ describe("Future", () => {
       assert.strictEqual(result, undefined);
       s.push("b");
       assert.strictEqual(result, "b");
+    });
+  });
+  describe("mapCbFuture", () => {
+    it("resolves with result when done callback invoked", () => {
+      const fut = sinkFuture<number>();
+      const cb = spy();
+      let value;
+      let done;
+      const fut2 = mapCbFuture((v, d) => {
+        value = v;
+        done = d;
+      }, fut);
+      fut2.subscribe(cb);
+      fut.resolve(3);
+      assert.equal(value, 3);
+      assert.equal(cb.callCount, 0);
+      done(value + 1);
+      assert.equal(cb.callCount, 1);
+      assert.deepEqual(cb.args, [[4]]);
     });
   });
 });

--- a/test/now.ts
+++ b/test/now.ts
@@ -1,3 +1,15 @@
+import { assert } from "chai";
+import { spy } from "sinon";
+import {
+  lift,
+  callP,
+  IO,
+  withEffects,
+  withEffectsP,
+  go,
+  fgo
+} from "@funkia/jabz";
+
 import {
   testStreamFromObject,
   Behavior,
@@ -21,16 +33,7 @@ import {
   time,
   toPromise
 } from "../src";
-import { assert } from "chai";
-import {
-  lift,
-  callP,
-  IO,
-  withEffects,
-  withEffectsP,
-  go,
-  fgo
-} from "@funkia/jabz";
+import * as H from "../src";
 
 // A reference that can be mutated
 type Ref<A> = { ref: A };
@@ -240,7 +243,26 @@ describe("Now", () => {
       });
     });
   });
-
+  describe("performMap", () => {
+    it("runs callback and uses return value for stream", () => {
+      const s = H.sinkStream<number>();
+      const cb = spy();
+      const s2 = H.runNow(H.performMap((n) => n * n, s));
+      H.subscribe(cb, s2);
+      s.push(2);
+      s.push(3);
+      s.push(4);
+      assert.deepEqual(cb.args, [[4], [9], [16]]);
+    });
+    it("runs callback and uses return value for future", () => {
+      const fut = H.sinkFuture<number>();
+      const cb = spy();
+      const fut2 = H.runNow(H.performMap((n) => n * n, fut));
+      fut2.subscribe(cb);
+      fut.resolve(3);
+      assert.deepEqual(cb.args, [[9]]);
+    });
+  });
   describe("performStreamLatest", () => {
     it("work with one occurrence", (done: Function) => {
       let results: any[] = [];

--- a/test/now.ts
+++ b/test/now.ts
@@ -17,7 +17,7 @@ import {
   when,
   scan,
   Future,
-  perform,
+  performIO,
   Now,
   performStream,
   performStreamLatest,
@@ -84,8 +84,8 @@ describe("Now", () => {
     it("executes several `async`s in succession", async () => {
       const ref1 = createRef(1);
       const ref2 = createRef("Hello");
-      const comp = perform(mutateRef(2, ref1)).chain((_: any) =>
-        perform(mutateRef("World", ref2)).chain((__: any) =>
+      const comp = performIO(mutateRef(2, ref1)).chain((_: any) =>
+        performIO(mutateRef("World", ref2)).chain((__: any) =>
           Now.of(Future.of(true))
         )
       );
@@ -114,7 +114,9 @@ describe("Now", () => {
     it("works with runNow", () => {
       let resolve: (n: number) => void;
       const future = runNow(
-        perform(callP((n: number) => new Promise((res) => (resolve = res)), 0))
+        performIO(
+          callP((n: number) => new Promise((res) => (resolve = res)), 0)
+        )
       );
       setTimeout(() => {
         resolve(12);
@@ -167,7 +169,7 @@ describe("Now", () => {
         return Now.of(n * 2);
       }
       const prog = go(function*() {
-        const e: Future<number> = yield perform(fn(1));
+        const e: Future<number> = yield performIO(fn(1));
         const e2 = yield plan(e.map((r) => comp(r)));
         return e2;
       });
@@ -189,7 +191,7 @@ describe("Now", () => {
     });
     function loop(n: number): Now<Behavior<number>> {
       return go(function*() {
-        const nextNumber = yield perform(getNextNr(1));
+        const nextNumber = yield performIO(getNextNr(1));
         const future = yield plan(nextNumber.map(loop));
         return switchTo(Behavior.of(n), future);
       });


### PR DESCRIPTION
This PR adds `performMap` with the type:

```ts
export function performMap<A, B>(cb: (a: A) => B, f: Future<A>): Now<Future<B>>;
export function performMap<A, B>(cb: (a: A) => B, s: Stream<A>): Now<Stream<B>>;
```

The name `performMap` is only a suggestion. But it has at least two benefits:

* It includes "perform" which is consistent with the other `perform*` functions that run side-effects.
* It includes "map" to indicate that it closely resembles a `map`.