### PR TITLE
Stateful naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,21 +235,21 @@ A notorious problem in FRP is how to implement functions that return
 behaviors or streams that depend on the past. Such behaviors or
 streams are called "stateful"
 
-For instance `scan` creates a behavior that accumulates values over
+For instance `scanFrom` creates a behavior that accumulates values over
 time. Clearly such a behavior depends on the past. Thus we say that
-`scan` returns a stateful behavior.
+`scanFrom` returns a stateful behavior.
 
-Implementing stateful methods such as `scan` in a way that is both
+Implementing stateful methods such as `scanFrom` in a way that is both
 intuitive to use, pure and memory safe is very tricky.
 
-When implementing functions such as `scan` most reactive libraries in
+When implementing functions such as `scanFrom` most reactive libraries in
 JavaScript do one of these two things:
 
-* Calling `scan` doesn't begin accumulating state at all. Only when
-  someone starts observing the result of `scan` is state accumulated.
+* Calling `scanFrom` doesn't begin accumulating state at all. Only when
+  someone starts observing the result of `scanFrom` is state accumulated.
   This is very counter intuitive behavior.
-* Calling `scan` starts accumulating state from when `scan` is called.
-  This is pretty easy to understand. But it makes `scan` impure as it
+* Calling `scanFrom` starts accumulating state from when `scan` is called.
+  This is pretty easy to understand. But it makes `scanFrom` impure as it
   will not return the same behavior when called at different time.
 
 To solve this problem Hareactive uses a solution invented by Atze van
@@ -260,21 +260,21 @@ behavior and purity.
 The solution means that some functions return a value that, compared
 to what one might expect, is wrapped in an "extra" behavior. This
 "behavior wrapping" is applied to all functions that return a result
-that depends on the past. The before mentioned `scan`, for instance,
+that depends on the past. The before mentioned `scanFrom`, for instance,
 returns a value of type `Behavior<Behavior<A>>`.
 
 Remember that a behavior is a value that depends on time. It is a
 function from time. Therefore a behavior of a behavior is like a value
-that depends on _two_ moments in time. This makes sense for `scan`
+that depends on _two_ moments in time. This makes sense for `scanFrom`
 because the result of accumulating depends both on when we _start_
 accumulating and where we are now.
 
 To get rid of the extra layer of nesting we often use `sample`. The
 `sample` function returns a `Now`-computation that asks for the
-current value of a behavior. It has the type `(b: Behavior<A>) => Now<A>`. Using `sample` with `scan` looks like this.
+current value of a behavior. It has the type `(b: Behavior<A>) => Now<A>`. Using `sample` with `scanFrom` looks like this.
 
 ```js
-const count = sample(scan((acc, inc) => acc + inc, 0, incrementStream));
+const count = sample(scanFrom((acc, inc) => acc + inc, 0, incrementStream));
 ```
 
 Here `count` has type `Now<Behavior<A>>` and it represents a
@@ -305,8 +305,8 @@ this. The table below gives an overview.
 | Behavior | anything | `sample` (when inside Now) |
 | Behavior | Behavior | `flatten`                  |
 | Behavior | Stream   | `switchStream`             |
-| Stream   | Behavior | `switcher`, `selfie`       |
-| Stream   | Stream   | `switchStreamS`            |
+| Stream   | Behavior | `switcherFrom`, `selfie`   |
+| Stream   | Stream   | `switchStreamFrom`         |
 | Stream   | Future   | n/a                        |
 | Future   | Behavior | `switchTo`                 |
 
@@ -387,10 +387,10 @@ lift((n, m, q) => (n + m) / q, behaviorN, behaviorM, behaviorQ);
 
 #### How do I turn a stream into a behavior?
 
-You probably want `stepper`:
+You probably want `stepperFrom`:
 
 ```js
-const b = stepper(initial, stream);
+const b = stepperFrom(initial, stream);
 ```
 
 ### Creating behaviors and streams
@@ -502,7 +502,7 @@ considered. If it is `true` then the returned stream also has the
 occurrence—otherwise it doesn't. The behavior works as a filter that
 decides whether or not values are let through.
 
-#### `scanS<A, B>(fn: (a: A, b: B) => B, startingValue: B, stream: Stream<A>): Behavior<Stream<B>>`
+#### `scanFrom<A, B>(fn: (a: A, b: B) => B, startingValue: B, stream: Stream<A>): Behavior<Stream<B>>`
 
 A stateful scan.
 
@@ -608,7 +608,7 @@ contionusly changing, like `Date.now`.
 
 Returns `true` if `b` is a behavior and `false` otherwise.
 
-#### `when(b: Behavior<boolean>): Behavior<Future<{}>>`
+#### `whenFrom(b: Behavior<boolean>): Behavior<Future<{}>>`
 
 Takes a boolean valued behavior an returns a behavior that at any
 point in time contains a future that occurs in the next moment where
@@ -626,15 +626,15 @@ future occurs.
 Creates a new behavior that acts exactly like `initial` until `next`
 occurs after which it acts like the behavior it contains.
 
-#### `switcher<A>(init: Behavior<A>, s: Stream<Behavior<A>>): Behavior<Behavior<A>>`
+#### `switcherFrom<A>(init: Behavior<A>, s: Stream<Behavior<A>>): Behavior<Behavior<A>>`
 
 A behavior of a behavior that switches to the latest behavior from `s`.
 
-#### `stepper<B>(initial: B, steps: Stream<B>): Behavior<Behavior<B>>`
+#### `stepperFrom<B>(initial: B, steps: Stream<B>): Behavior<Behavior<B>>`
 
 Creates a behavior whose value is the last occurrence in the stream.
 
-#### `scan<A, B>(fn: (a: A, b: B) => B, init: B, source: Stream<A>): Behavior<Behavior<B>>`
+#### `scanFrom<A, B>(fn: (a: A, b: B) => B, init: B, source: Stream<A>): Behavior<Behavior<B>>`
 
 The returned behavior initially has the initial value, on each
 occurrence in `source` the function is applied to the current value of
@@ -653,7 +653,7 @@ behavior gives a behavior with values that contain the difference
 between the current sample time and the time at which the outer
 behavior was sampled.
 
-#### `integrate(behavior: Behavior<number>): Behavior<Behavior<number>>`
+#### `integrateFrom(behavior: Behavior<number>): Behavior<Behavior<number>>`
 
 Integrate behavior with respect to time.
 

--- a/README.md
+++ b/README.md
@@ -12,20 +12,20 @@ performant.
 
 ## Key features
 
-* Simple and precise semantics. This means that everything in the
+- Simple and precise semantics. This means that everything in the
   library can be understood based on a very simple mental model. This
   makes the library easy to use and free from surprises.
-* Purely functional API.
-* Based on classic FRP. This means that the library makes a
+- Purely functional API.
+- Based on classic FRP. This means that the library makes a
   distinction between behaviors and streams.
-* Supports continuous time for expressive and efficient creation of
+- Supports continuous time for expressive and efficient creation of
   time-dependent behavior.
-* Integrates with declarative side-effects in a way that is pure,
+- Integrates with declarative side-effects in a way that is pure,
   testable and uses FRP for powerful handling of asynchronous
   operations.
-* Declarative testing. Hareactive programs are easy to test
+- Declarative testing. Hareactive programs are easy to test
   synchronously and declaratively.
-* Great performance.
+- Great performance.
 
 ## Introduction
 
@@ -54,12 +54,12 @@ time.
 
 ## Table of contents
 
-* [Installation](#installation)
-* [Conceptual overview](#conceptual-overview)
-* [Tutorial/cookbook](#tutorial-cookbook)
-* [API documentation](#api)
-* [Contributing](#contributing)
-* [Benchmark](#benchmark)
+- [Installation](#installation)
+- [Conceptual overview](#conceptual-overview)
+- [Tutorial/cookbook](#tutorial-cookbook)
+- [API documentation](#api)
+- [Contributing](#contributing)
+- [Benchmark](#benchmark)
 
 # Installation
 
@@ -187,17 +187,17 @@ a behavior:
 
 Below are some examples:
 
-* The time remaining before an alarm goes off: The remaining time
+- The time remaining before an alarm goes off: The remaining time
   always have a current value, therefore it is a behavior.
-* The moment where the alarm goes off: This has no current value. And
+- The moment where the alarm goes off: This has no current value. And
   since the alarm only goes off a single time this is a future.
-* User clicking on a specific button: This has no notion of a current
+- User clicking on a specific button: This has no notion of a current
   value. And the user may press the button more than once. Thus a
   stream is the proper representation.
-* Whether or not a button is currently pressed: This always has a
+- Whether or not a button is currently pressed: This always has a
   current value. The button is always either pressed or not pressed.
   This should be represented as a behavior.
-* The tenth time a button is pressed: This happens once at a specific
+- The tenth time a button is pressed: This happens once at a specific
   moment in time. Use a future.
 
 ### Now
@@ -210,10 +210,10 @@ A value of type `Now` is a _description_ of something that we'd like
 to do. Such a description can declare that it wants to do one of two
 things.
 
-* Get the current value of behavior. This is done with the `sample`
+- Get the current value of behavior. This is done with the `sample`
   function. Since a `Now`-computation will always be run in the
   present it is impossible to sample a behavior in the past.
-* Describe side-effects. This is done with functions such as `perform`
+- Describe side-effects. This is done with functions such as `perform`
   and `performStream`. With these functions we can describe things
   that should happen when a stream occurs.
 
@@ -235,21 +235,21 @@ A notorious problem in FRP is how to implement functions that return
 behaviors or streams that depend on the past. Such behaviors or
 streams are called "stateful"
 
-For instance `scanFrom` creates a behavior that accumulates values over
+For instance `accumFrom` creates a behavior that accumulates values over
 time. Clearly such a behavior depends on the past. Thus we say that
-`scanFrom` returns a stateful behavior.
+`accumFrom` returns a stateful behavior.
 
-Implementing stateful methods such as `scanFrom` in a way that is both
+Implementing stateful methods such as `accumFrom` in a way that is both
 intuitive to use, pure and memory safe is very tricky.
 
-When implementing functions such as `scanFrom` most reactive libraries in
+When implementing functions such as `accumFrom` most reactive libraries in
 JavaScript do one of these two things:
 
-* Calling `scanFrom` doesn't begin accumulating state at all. Only when
-  someone starts observing the result of `scanFrom` is state accumulated.
+- Calling `accumFrom` doesn't begin accumulating state at all. Only when
+  someone starts observing the result of `accumFrom` is state accumulated.
   This is very counter intuitive behavior.
-* Calling `scanFrom` starts accumulating state from when `scan` is called.
-  This is pretty easy to understand. But it makes `scanFrom` impure as it
+- Calling `accumFrom` starts accumulating state from when `accumFrom` is called.
+  This is pretty easy to understand. But it makes `accumFrom` impure as it
   will not return the same behavior when called at different time.
 
 To solve this problem Hareactive uses a solution invented by Atze van
@@ -260,21 +260,21 @@ behavior and purity.
 The solution means that some functions return a value that, compared
 to what one might expect, is wrapped in an "extra" behavior. This
 "behavior wrapping" is applied to all functions that return a result
-that depends on the past. The before mentioned `scanFrom`, for instance,
+that depends on the past. The before mentioned `accumFrom`, for instance,
 returns a value of type `Behavior<Behavior<A>>`.
 
 Remember that a behavior is a value that depends on time. It is a
 function from time. Therefore a behavior of a behavior is like a value
-that depends on _two_ moments in time. This makes sense for `scanFrom`
+that depends on _two_ moments in time. This makes sense for `accumFrom`
 because the result of accumulating depends both on when we _start_
 accumulating and where we are now.
 
 To get rid of the extra layer of nesting we often use `sample`. The
 `sample` function returns a `Now`-computation that asks for the
-current value of a behavior. It has the type `(b: Behavior<A>) => Now<A>`. Using `sample` with `scanFrom` looks like this.
+current value of a behavior. It has the type `(b: Behavior<A>) => Now<A>`. Using `sample` with `accumFrom` looks like this.
 
 ```js
-const count = sample(scanFrom((acc, inc) => acc + inc, 0, incrementStream));
+const count = sample(accumFrom((acc, inc) => acc + inc, 0, incrementStream));
 ```
 
 Here `count` has type `Now<Behavior<A>>` and it represents a
@@ -450,7 +450,7 @@ occurred the consumer is immediately pushed to.
 
 #### `empty: Stream<any>`
 
-Empty stream. 
+Empty stream.
 
 #### ~`Stream.of<A>(a: A): Stream<A>`~
 
@@ -546,6 +546,7 @@ always "switches" to the current stream at the behavior.
 ```ts
 changes<A>(b: Behavior<A>, comparator: (v: A, u: A) => boolean = (v, u) => v === u): Stream<A>;
 ```
+
 Takes a behavior and returns a stream that has an occurrence whenever
 the behaviors value changes.
 

--- a/src/animation.ts
+++ b/src/animation.ts
@@ -1,5 +1,13 @@
 import { go } from "@funkia/jabz";
-import { Behavior, stepper, time, scan, Stream, snapshot, lift } from ".";
+import {
+  Behavior,
+  stepperFrom,
+  time,
+  accumFrom,
+  Stream,
+  snapshot,
+  lift
+} from ".";
 
 export type TimingFunction = (t: number) => number;
 
@@ -21,13 +29,13 @@ export function transitionBehavior(
   timeB: Behavior<number> = time
 ): Behavior<Behavior<number>> {
   return go(function*(): any {
-    const rangeValueB: Behavior<Range> = yield scan(
+    const rangeValueB: Behavior<Range> = yield accumFrom(
       (newV, prev) => ({ from: prev.to, to: newV }),
       { from: initial, to: initial },
       triggerStream
     );
     const initialStartTime: number = yield timeB;
-    const startTimeB: Behavior<number> = yield stepper(
+    const startTimeB: Behavior<number> = yield stepperFrom(
       initialStartTime,
       snapshot(timeB, triggerStream)
     );

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -317,6 +317,10 @@ export function whenFrom(b: Behavior<boolean>): Behavior<Future<{}>> {
   return new WhenBehavior(b);
 }
 
+export function when(b: Behavior<boolean>): Now<Future<{}>> {
+  return sample(whenFrom(b));
+}
+
 class SnapshotBehavior<A> extends Behavior<Future<A>> implements SListener<A> {
   private afterFuture: boolean;
   private node: Node<this> = new Node(this);
@@ -453,6 +457,13 @@ export function switcherFrom<A>(
   return fromFunction((t) => new SwitcherBehavior(init, stream, t));
 }
 
+export function switcher<A>(
+  init: Behavior<A>,
+  stream: Stream<Behavior<A>>
+): Now<Behavior<A>> {
+  return sample(switcherFrom(init, stream));
+}
+
 export function freezeTo<A>(
   init: Behavior<A>,
   freezeValue: Future<A>
@@ -460,11 +471,17 @@ export function freezeTo<A>(
   return switchTo(init, freezeValue.map(Behavior.of));
 }
 
-export function freezeAt<A>(
+export function freezeAtFrom<A>(
   behavior: Behavior<A>,
   shouldFreeze: Future<any>
 ): Behavior<Behavior<A>> {
   return snapshotAt(behavior, shouldFreeze).map((f) => freezeTo(behavior, f));
+}
+export function freezeAt<A>(
+  behavior: Behavior<A>,
+  shouldFreeze: Future<any>
+): Now<Behavior<A>> {
+  return sample(freezeAtFrom(behavior, shouldFreeze));
 }
 
 /** @private */

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -477,6 +477,7 @@ export function freezeAtFrom<A>(
 ): Behavior<Behavior<A>> {
   return snapshotAt(behavior, shouldFreeze).map((f) => freezeTo(behavior, f));
 }
+
 export function freezeAt<A>(
   behavior: Behavior<A>,
   shouldFreeze: Future<any>
@@ -485,7 +486,7 @@ export function freezeAt<A>(
 }
 
 /** @private */
-class ActiveScanBehavior<A, B> extends ActiveBehavior<B>
+class ActiveAccumBehavior<A, B> extends ActiveBehavior<B>
   implements SListener<A> {
   private node: Node<this> = new Node(this);
   constructor(
@@ -511,7 +512,7 @@ class ActiveScanBehavior<A, B> extends ActiveBehavior<B>
     throw new Error("Update should never be called.");
   }
   changeStateDown(state: State): void {
-    // No-op as an `ActiveScanBehavior` is always in `Push` state
+    // No-op as an `ActiveAccumBehavior` is always in `Push` state
   }
 }
 
@@ -525,7 +526,7 @@ export class AccumBehavior<A, B> extends ActiveBehavior<Behavior<B>> {
     this.state = State.Pull;
   }
   update(t: number): Behavior<B> {
-    return new ActiveScanBehavior(this.f, this.initial, this.source, t);
+    return new ActiveAccumBehavior(this.f, this.initial, this.source, t);
   }
   pull(t: Time): void {
     this.last = this.update(t);
@@ -598,7 +599,7 @@ export function stepper<B>(initial: B, steps: Stream<B>): Now<Behavior<B>> {
 }
 
 /**
- *
+ * Creates a Behavior whose value is `true` after `turnOn` occurring and `false` after `turnOff` occurring.
  * @param initial the initial value
  * @param turnOn the streams that turn the behavior on
  * @param turnOff the streams that turn the behavior off
@@ -612,7 +613,7 @@ export function toggleFrom(
 }
 
 /**
- *
+ * Creates a Behavior whose value is `true` after `turnOn` occurring and `false` after `turnOff` occurring.
  * @param initial the initial value
  * @param turnOn the streams that turn the behavior on
  * @param turnOff the streams that turn the behavior off

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -5,7 +5,7 @@ import { Future, BehaviorFuture } from "./future";
 import * as F from "./future";
 import { Stream } from "./stream";
 import { tick, getTime } from "./clock";
-import { sample, Now } from "../";
+import { sample, Now } from "./now";
 
 export type MapBehaviorTuple<A> = { [K in keyof A]: Behavior<A[K]> };
 
@@ -525,6 +525,14 @@ export function accumFrom<A, B>(
   return new AccumBehavior<A, B>(f, initial, source);
 }
 
+export function accum<A, B>(
+  f: (a: A, b: B) => B,
+  initial: B,
+  source: Stream<A>
+): Now<Behavior<B>> {
+  return sample(accumFrom(f, initial, source));
+}
+
 export type AccumPair<A> = [Stream<any>, (a: any, b: A) => A];
 
 function accumPairToApp<A>([stream, fn]: AccumPair<A>): Stream<(a: A) => A> {
@@ -542,6 +550,13 @@ export function accumCombineFrom<B>(
   );
 }
 
+export function accumCombine<B>(
+  pairs: AccumPair<B>[],
+  initial: B
+): Now<Behavior<B>> {
+  return sample(accumCombineFrom(pairs, initial));
+}
+
 const firstArg = (a, b) => a;
 
 /**
@@ -557,6 +572,15 @@ export function stepperFrom<B>(
 }
 
 /**
+ * Creates a Behavior whose value is the last occurrence in the stream.
+ * @param initial - the initial value that the behavior has
+ * @param steps - the stream that will change the value of the behavior
+ */
+export function stepper<B>(initial: B, steps: Stream<B>): Now<Behavior<B>> {
+  return sample(stepperFrom(initial, steps));
+}
+
+/**
  *
  * @param initial the initial value
  * @param turnOn the streams that turn the behavior on
@@ -568,6 +592,20 @@ export function toggleFrom(
   turnOff: Stream<any>
 ): Behavior<Behavior<boolean>> {
   return stepperFrom(initial, turnOn.mapTo(true).combine(turnOff.mapTo(false)));
+}
+
+/**
+ *
+ * @param initial the initial value
+ * @param turnOn the streams that turn the behavior on
+ * @param turnOff the streams that turn the behavior off
+ */
+export function toggle(
+  initial: boolean,
+  turnOn: Stream<any>,
+  turnOff: Stream<any>
+): Now<Behavior<boolean>> {
+  return sample(toggleFrom(initial, turnOn, turnOff));
 }
 
 export type SampleAt = <B>(b: Behavior<B>) => B;

--- a/src/future.ts
+++ b/src/future.ts
@@ -240,7 +240,7 @@ export class BehaviorFuture<A> extends SinkFuture<A> implements BListener {
   }
 }
 
-export class NextOccurenceFuture<A> extends Future<A> implements SListener<A> {
+export class NextOccurrenceFuture<A> extends Future<A> implements SListener<A> {
   constructor(readonly s: Stream<A>, readonly time: Time) {
     super();
     this.parents = cons(s);
@@ -250,8 +250,8 @@ export class NextOccurenceFuture<A> extends Future<A> implements SListener<A> {
   }
 }
 
-export function nextOccurence<A>(stream: Stream<A>): Behavior<Future<A>> {
-  return new FunctionBehavior((t: Time) => new NextOccurenceFuture(stream, t));
+export function nextOccurrenceFrom<A>(stream: Stream<A>): Behavior<Future<A>> {
+  return new FunctionBehavior((t: Time) => new NextOccurrenceFuture(stream, t));
 }
 
 class MapCbFuture<A, B> extends ActiveFuture<B> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
-import { Stream, SinkStream, empty } from "./stream";
-import { Behavior, SinkBehavior, MapBehaviorTuple } from "./behavior";
 import { Now } from "./now";
+import { Stream, SinkStream } from "./stream";
+import { Behavior, SinkBehavior, MapBehaviorTuple } from "./behavior";
 import { Future, MapFutureTuple } from "./future";
 
 export * from "./common";
+export * from "./now";
 export * from "./behavior";
 export * from "./stream";
 export * from "./future";
-export * from "./now";
 export * from "./dom";
 export * from "./time";
 export * from "./placeholder";

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -115,7 +115,7 @@ function installMethods(): void {
 }
 
 export function placeholder<A>(): Placeholder<A> & Stream<A> & Future<A> {
-  if ((<any>Placeholder).prototype.scanS === undefined) {
+  if ((<any>Placeholder).prototype.scanFrom === undefined) {
     // The methods are installed lazily when the placeholder is first
     // used. This avoids a top-level impure expression that would
     // prevent tree-shaking.

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -13,7 +13,7 @@ import {
 import {
   Behavior,
   MapBehavior,
-  ScanBehavior,
+  AccumBehavior,
   FunctionBehavior,
   ConstantBehavior
 } from "./behavior";
@@ -26,7 +26,7 @@ import {
   OfFuture,
   LiftFuture,
   FlatMapFuture,
-  NextOccurenceFuture
+  NextOccurrenceFuture
 } from "./future";
 import { Time } from "./common";
 import {
@@ -114,8 +114,8 @@ FlatMapFuture.prototype.model = function() {
   return neverOccurringFuture;
 };
 
-NextOccurenceFuture.prototype.model = function<A>(
-  this: NextOccurenceFuture<A>
+NextOccurrenceFuture.prototype.model = function<A>(
+  this: NextOccurrenceFuture<A>
 ) {
   const occ = this.s.model().find((o) => o.time > this.time);
   return occ !== undefined ? occ : neverOccurringFuture;
@@ -181,12 +181,10 @@ empty.model = () => [];
 ScanStream.prototype.model = function<A, B>(this: ScanStream<A, B>) {
   const s = this.parent.model();
   let acc = this.last;
-  return s
-    .filter((o) => this.t < o.time)
-    .map(({ time, value }) => {
-      acc = this.f(value, acc);
-      return { time, value: acc };
-    });
+  return s.filter((o) => this.t < o.time).map(({ time, value }) => {
+    acc = this.f(value, acc);
+    return { time, value: acc };
+  });
 };
 
 CombineStream.prototype.model = function<A, B>(this: CombineStream<A, B>) {
@@ -206,9 +204,9 @@ CombineStream.prototype.model = function<A, B>(this: CombineStream<A, B>) {
 };
 
 SnapshotStream.prototype.model = function<B>(this: SnapshotStream<B>) {
-  return this.stream
+  return this.trigger
     .model()
-    .map(({ time }) => ({ time, value: testAt(time, this.behavior) }));
+    .map(({ time }) => ({ time, value: testAt(time, this.target) }));
 };
 
 DelayStream.prototype.model = function<A>(this: DelayStream<A>) {
@@ -264,8 +262,8 @@ export function assertStreamEqual<A>(s1: Stream<A>, s2): void {
   const s2_ = isStream(s2)
     ? s2
     : Array.isArray(s2)
-    ? testStreamFromArray(s2)
-    : testStreamFromObject(s2);
+      ? testStreamFromArray(s2)
+      : testStreamFromObject(s2);
   assert.deepEqual(s1.model(), s2_.model());
 }
 
@@ -294,7 +292,7 @@ FunctionBehavior.prototype.model = function() {
 
 time.model = () => (t: Time) => t;
 
-ScanBehavior.prototype.model = function<A, B>(this: ScanBehavior<A, B>) {
+AccumBehavior.prototype.model = function<A, B>(this: AccumBehavior<A, B>) {
   const stream = this.source.model();
   return (t1) =>
     testBehavior<B>((t2) =>

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -181,10 +181,12 @@ empty.model = () => [];
 ScanStream.prototype.model = function<A, B>(this: ScanStream<A, B>) {
   const s = this.parent.model();
   let acc = this.last;
-  return s.filter((o) => this.t < o.time).map(({ time, value }) => {
-    acc = this.f(value, acc);
-    return { time, value: acc };
-  });
+  return s
+    .filter((o) => this.t < o.time)
+    .map(({ time, value }) => {
+      acc = this.f(value, acc);
+      return { time, value: acc };
+    });
 };
 
 CombineStream.prototype.model = function<A, B>(this: CombineStream<A, B>) {
@@ -262,8 +264,8 @@ export function assertStreamEqual<A>(s1: Stream<A>, s2): void {
   const s2_ = isStream(s2)
     ? s2
     : Array.isArray(s2)
-      ? testStreamFromArray(s2)
-      : testStreamFromObject(s2);
+    ? testStreamFromArray(s2)
+    : testStreamFromObject(s2);
   assert.deepEqual(s1.model(), s2_.model());
 }
 

--- a/src/time.ts
+++ b/src/time.ts
@@ -2,6 +2,7 @@ import { Time, State } from "./common";
 import { cons } from "./datastructures";
 import { Stream } from "./stream";
 import { Behavior, fromFunction } from "./behavior";
+import { sample, Now } from "./now";
 
 /*
  * Time related behaviors and functions
@@ -96,8 +97,12 @@ class IntegrateBehavior extends Behavior<number> {
   }
 }
 
-export function integrate(
+export function integrateFrom(
   behavior: Behavior<number>
 ): Behavior<Behavior<number>> {
   return fromFunction((t) => new IntegrateBehavior(behavior, t));
+}
+
+export function integrate(behavior: Behavior<number>): Now<Behavior<number>> {
+  return sample(integrateFrom(behavior));
 }

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -426,9 +426,7 @@ describe("behavior", () => {
       const b = H.fromFunction(() => {
         throw new Error("Must not be called");
       });
-      const result = H.runNow(
-        H.sample(H.integrateFrom(b)).chain((bi) => H.sample(bi))
-      );
+      const result = H.runNow(H.integrate(b).chain((bi) => H.sample(bi)));
       assert.strictEqual(result, 0);
     });
   });

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -19,7 +19,8 @@ import {
   freezeTo,
   freezeAtFrom,
   Stream,
-  time
+  time,
+  runNow
 } from "../src";
 
 import * as H from "../src";
@@ -378,7 +379,7 @@ describe("behavior", () => {
       H.flatten(b).map((s) => s + "bar");
     });
   });
-  describe("integrate", () => {
+  describe("integrateFrom", () => {
     it("can integrate", () => {
       const clock = useFakeTimers();
       const acceleration = sinkBehavior(1);
@@ -558,12 +559,11 @@ describe("behavior", () => {
 });
 
 describe("Behavior and Future", () => {
-  describe("when", () => {
+  describe("whenFrom", () => {
     it("gives occurred future when behavior is true", () => {
       let occurred = false;
       const b = Behavior.of(true);
-      const w = H.whenFrom(b);
-      const fut = at(w);
+      const fut = runNow(H.when(b));
       fut.subscribe((_) => (occurred = true));
       assert.strictEqual(occurred, true);
     });
@@ -690,7 +690,7 @@ describe("Behavior and Future", () => {
       const cb = spy();
       const b = sinkBehavior("a");
       const f = sinkFuture<string>();
-      const frozenBehavior = freezeAtFrom(b, f).at();
+      const frozenBehavior = runNow(H.freezeAt(b, f));
       frozenBehavior.subscribe(cb);
       b.push("b");
       f.resolve("c");
@@ -705,20 +705,20 @@ describe("Behavior and Stream", () => {
       const result: number[] = [];
       const stream = H.sinkStream<Behavior<number>>();
       const initB = Behavior.of(1);
-      const outerSwitcher = H.switcherFrom(initB, stream);
-      const switchingB = at(outerSwitcher);
+      const outerSwitcher = H.switcher(initB, stream);
+      const switchingB = runNow(outerSwitcher);
       switchingB.subscribe((n) => result.push(n));
       const sinkB = sinkBehavior(2);
       stream.push(sinkB);
       sinkB.push(3);
       assert.deepEqual(result, [1, 2, 3]);
-      assert.deepEqual(at(at(outerSwitcher)), 1);
+      assert.deepEqual(at(runNow(outerSwitcher)), 1);
     });
   });
   describe("stepper", () => {
     it("steps to the last event value", () => {
       const s = H.sinkStream();
-      const b = H.stepperFrom(0, s).at();
+      const b = runNow(H.stepper(0, s));
       const cb = subscribeSpy(b);
       s.push(1);
       s.push(2);
@@ -726,14 +726,14 @@ describe("Behavior and Stream", () => {
     });
     it("saves last occurrence from stream", () => {
       const s = H.sinkStream();
-      const t = H.stepperFrom(1, s).at();
+      const t = runNow(H.stepper(1, s));
       s.push(12);
       const spy = subscribeSpy(t);
       assert.deepEqual(spy.args, [[12]]);
     });
     it("has old value in exact moment", () => {
       const s = H.sinkStream();
-      const b = H.stepperFrom(0, s).at();
+      const b = runNow(H.stepper(0, s));
       const res = H.snapshot(b, s);
       const spy = subscribeSpy(res);
       s.push(1);
@@ -743,19 +743,19 @@ describe("Behavior and Stream", () => {
       assert.deepEqual(spy.args, [[0], [1]]);
     });
   });
-  describe("scan", () => {
-    it("has scan as method on stream", () => {
-      const scanned = H.empty.scanFrom(sum, 0);
+  describe("accum", () => {
+    it("has accumFrom as method on stream", () => {
+      const accumulated = H.empty.accumFrom(sum, 0);
     });
     it("accumulates in a pure way", () => {
       const s = H.sinkStream<number>();
-      const scanned = H.accumFrom(sum, 1, s);
-      const b1 = scanned.at();
+      const accumulated = H.accumFrom(sum, 1, s);
+      const b1 = at(accumulated);
       const spy = subscribeSpy(b1);
       assert.strictEqual(at(b1), 1);
       s.push(2);
       assert.strictEqual(at(b1), 3);
-      const b2 = at(scanned);
+      const b2 = at(accumulated);
       assert.strictEqual(at(b2), 1);
       s.push(4);
       assert.strictEqual(at(b1), 7);
@@ -765,29 +765,30 @@ describe("Behavior and Stream", () => {
     it("works with placeholder", () => {
       const s = H.sinkStream<number>();
       const ps = H.placeholder();
-      const scanned = H.accumFrom(sum, 1, ps);
-      const b = scanned.at();
+      const accumulated = runNow(ps.accum(sum, 1));
       ps.replaceWith(s);
       s.push(2);
       s.push(3);
       s.push(4);
-      assert.strictEqual(b.at(), 10);
+      assert.strictEqual(accumulated.at(), 10);
     });
   });
-  describe("scanCombine", () => {
+  describe("scanCombineFrom", () => {
     it("combines several streams", () => {
       const add = H.sinkStream();
       const sub = H.sinkStream();
       const mul = H.sinkStream();
-      const b = H.accumCombineFrom(
-        [
-          [add, (n, m) => n + m],
-          [sub, (n, m) => m - n],
-          [mul, (n, m) => n * m]
-        ],
-        1
+      const b = runNow(
+        H.accumCombine(
+          [
+            [add, (n, m) => n + m],
+            [sub, (n, m) => m - n],
+            [mul, (n, m) => n * m]
+          ],
+          1
+        )
       );
-      const cb = subscribeSpy(b.at());
+      const cb = subscribeSpy(b);
       add.push(3);
       mul.push(3);
       sub.push(5);
@@ -878,15 +879,15 @@ describe("Behavior and Stream", () => {
     it("has correct initial value", () => {
       const s1 = H.sinkStream();
       const s2 = H.sinkStream();
-      const flipper1 = H.toggleFrom(true, s1, s2).at();
+      const flipper1 = runNow(H.toggle(true, s1, s2));
       assert.strictEqual(at(flipper1), true);
-      const flipper2 = H.toggleFrom(false, s1, s2).at();
+      const flipper2 = runNow(H.toggle(false, s1, s2));
       assert.strictEqual(at(flipper2), false);
     });
     it("flips properly", () => {
       const s1 = H.sinkStream();
       const s2 = H.sinkStream();
-      const flipper = H.toggleFrom(false, s1, s2).at();
+      const flipper = runNow(H.toggle(false, s1, s2));
       const cb = subscribeSpy(flipper);
       s1.push(1);
       s2.push(2);

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -17,7 +17,7 @@ import {
   fromFunction,
   sinkFuture,
   freezeTo,
-  freezeAt,
+  freezeAtFrom,
   Stream,
   time
 } from "../src";
@@ -690,7 +690,7 @@ describe("Behavior and Future", () => {
       const cb = spy();
       const b = sinkBehavior("a");
       const f = sinkFuture<string>();
-      const frozenBehavior = freezeAt(b, f).at();
+      const frozenBehavior = freezeAtFrom(b, f).at();
       frozenBehavior.subscribe(cb);
       b.push("b");
       f.resolve("c");

--- a/test/future.ts
+++ b/test/future.ts
@@ -5,7 +5,7 @@ import {
   Future,
   sinkFuture,
   fromPromise,
-  nextOccurence,
+  nextOccurrenceFrom,
   mapCbFuture
 } from "../src/future";
 import { SinkStream, Behavior } from "../src";
@@ -202,7 +202,7 @@ describe("Future", () => {
     it("resolves on next occurence", () => {
       let result: string;
       const s = new SinkStream<string>();
-      const next = nextOccurence(s);
+      const next = nextOccurrenceFrom(s);
       s.push("a");
       const f = next.at();
       f.subscribe((v) => (result = v));

--- a/test/now.ts
+++ b/test/now.ts
@@ -5,7 +5,7 @@ import { lift, callP, withEffects, withEffectsP, go, fgo } from "@funkia/jabz";
 import {
   Behavior,
   switchTo,
-  when,
+  whenFrom,
   Future,
   performIO,
   Now,
@@ -155,7 +155,7 @@ describe("Now", () => {
       return go(function*() {
         const b: Behavior<number> = yield loop(0);
         const e = yield sample(
-          when(
+          whenFrom(
             b.map((n: number) => {
               return n === 3;
             })

--- a/test/placeholder.ts
+++ b/test/placeholder.ts
@@ -7,7 +7,7 @@ import { observe } from "../src/common";
 import {
   isBehavior,
   Behavior,
-  stepper,
+  stepperFrom,
   fromFunction,
   sinkBehavior,
   ap,
@@ -118,7 +118,7 @@ describe("placeholder", () => {
     });
     it("pushes if replaced with pushing behavior", () => {
       const stream = sinkStream();
-      const b = stepper(0, stream).at();
+      const b = stepperFrom(0, stream).at();
       const p = placeholder();
       // We replace with a behavior that does not support pulling
       p.replaceWith(b);
@@ -187,7 +187,7 @@ describe("placeholder", () => {
       setTime(2000);
       const sum = H.placeholder<number>();
       const change = sum.map((_) => 1);
-      const sum2 = H.at(H.switcher(H.at(H.integrate(change)), H.empty));
+      const sum2 = H.at(H.switcherFrom(H.at(H.integrateFrom(change)), H.empty));
       const results = [];
       let pull;
       observe(

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -242,7 +242,7 @@ describe("stream", () => {
       const eventS = H.sinkStream();
       const callback = spy();
       const sumF = (currSum: number, val: number) => currSum + val;
-      const currentSumE = H.scanS(sumF, 0, eventS).at();
+      const currentSumE = H.scanFrom(sumF, 0, eventS).at();
       H.subscribe(callback, currentSumE);
       for (let i = 0; i < 10; i++) {
         push(i, eventS);

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -237,12 +237,12 @@ describe("stream", () => {
     });
   });
 
-  describe("scanS", () => {
+  describe("scan", () => {
     it("should scan the values to a stream", () => {
       const eventS = H.sinkStream();
       const callback = spy();
       const sumF = (currSum: number, val: number) => currSum + val;
-      const currentSumE = H.scanFrom(sumF, 0, eventS).at();
+      const currentSumE = H.runNow(eventS.scan(sumF, 0));
       H.subscribe(callback, currentSumE);
       for (let i = 0; i < 10; i++) {
         push(i, eventS);
@@ -261,7 +261,27 @@ describe("stream", () => {
       ]);
     });
   });
-
+  describe("switchStreamFrom", () => {
+    it("returns stream that emits from latest stream", () => {
+      const s1 = H.sinkStream<number>();
+      const s2 = H.sinkStream<number>();
+      const s3 = H.sinkStream<number>();
+      const b = H.sinkStream<H.Stream<number>>();
+      const switching = H.switchStreamFrom(b).at();
+      const cb = spy();
+      switching.subscribe(cb);
+      b.push(s1);
+      s1.push(1);
+      s1.push(2);
+      b.push(s2);
+      s2.push(3);
+      b.push(s3);
+      s2.push(4);
+      s3.push(5);
+      s3.push(6);
+      assert.deepEqual(cb.args, [[1], [2], [3], [5], [6]]);
+    });
+  });
   describe("keepWhen", () => {
     it("removes occurrences when behavior is false", () => {
       let flag = true;


### PR DESCRIPTION
I have renamed all the stateful operators with the suffix `From` and for each created a sampled version for convenience.
Besides the suffix, I have also renamed:
`scan` to `accumFrom`
`scanS` to `scanFrom`