### PR TITLE
Make dom it's own module, add keyboard functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "files": [
     "dist",
+    "dom",
     "testing"
   ],
   "scripts": {

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -149,32 +149,33 @@ function pullOnFrame(pull: (t?: number) => void): () => void {
 }
 
 /**
- * Returns a stream that has an occurrence whenever the key described by the
- * code is pressed down.
- *
- * The code is a [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code).
+ * Returns a stream that has an occurrence whenever a key is pressed down. The
+ * value is the
+ * [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent)
+ * associated with the key press.
  */
-export function keyDown(code: string): Stream<KeyboardEvent> {
-  return streamFromEvent(window, "keydown").filter((e) => e.code === code);
-}
+export const keyDown: Stream<KeyboardEvent> = streamFromEvent(
+  window,
+  "keydown"
+);
 
 /**
- * Returns a stream that has an occurrence whenever the key described by the
- * code is released.
- *
- * The code is a [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code).
+ * Returns a stream that has an occurrence whenever a key is pressed down. The
+ * value is the
+ * [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent)
+ * associated with the key press.
  */
-export function keyUp(code: string): Stream<KeyboardEvent> {
-  return streamFromEvent(window, "keyup").filter((e) => e.code === code);
-}
+export const keyUp: Stream<KeyboardEvent> = streamFromEvent(window, "keyup");
 
 /**
- * Returns a behavior that is true when the key is pressed.
+ * Returns a behavior that is true when the key is pressed and false then the
+ * key is not pressed.
  *
  * The code is a [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code).
  */
 export function keyPressed(code: string): Now<Behavior<boolean>> {
-  return toggle(false, keyDown(code), keyUp(code));
+  const isKey = (e: KeyboardEvent) => e.code === code;
+  return toggle(false, keyDown.filter(isKey), keyUp.filter(isKey));
 }
 
 /**

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,6 +1,7 @@
 import { observe } from "./common";
 import { Stream, ProducerStream } from "./stream";
-import { Behavior, ProducerBehavior } from "./behavior";
+import { Behavior, ProducerBehavior, toggle } from "./behavior";
+import { Now } from "./now";
 
 export type HTMLEventName = keyof HTMLElementEventMap;
 export type WindowEventName = keyof WindowEventMap;
@@ -145,6 +146,35 @@ function pullOnFrame(pull: (t?: number) => void): () => void {
   return () => {
     isPulling = false;
   };
+}
+
+/**
+ * Returns a stream that has an occurrence whenever the key described by the
+ * code is pressed down.
+ *
+ * The code is a [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code).
+ */
+export function keyDown(code: string): Stream<KeyboardEvent> {
+  return streamFromEvent(window, "keydown").filter((e) => e.code === code);
+}
+
+/**
+ * Returns a stream that has an occurrence whenever the key described by the
+ * code is released.
+ *
+ * The code is a [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code).
+ */
+export function keyUp(code: string): Stream<KeyboardEvent> {
+  return streamFromEvent(window, "keyup").filter((e) => e.code === code);
+}
+
+/**
+ * Returns a behavior that is true when the key is pressed.
+ *
+ * The code is a [KeyboardEvent.code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code).
+ */
+export function keyPressed(code: string): Now<Behavior<boolean>> {
+  return toggle(false, keyDown(code), keyUp(code));
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ export * from "./now";
 export * from "./behavior";
 export * from "./stream";
 export * from "./future";
-export * from "./dom";
 export * from "./time";
 export * from "./placeholder";
 export * from "./animation";

--- a/test/dom.ts
+++ b/test/dom.ts
@@ -3,7 +3,7 @@ import { assert } from "chai";
 import * as browserEnv from "browser-env";
 
 import * as H from "../src/index";
-import { streamFromEvent, behaviorFromEvent } from "../src/dom";
+import { render, streamFromEvent, behaviorFromEvent } from "../src/dom";
 import "mocha";
 import { spy } from "sinon";
 
@@ -98,7 +98,7 @@ describe("dom", () => {
       let val = 0;
       const b = H.fromFunction((_) => val);
       const cb = spy();
-      H.render(cb, b);
+      render(cb, b);
       val = 1;
       fakeRaf.step();
       val = 2;


### PR DESCRIPTION
This PR makes the dom functions their own module imported as `@hareactive/funkia/dom`.

It also adds a few functions for accessing the keyboard: `keyDown`, `keyUp`, and `keyPressed`. If we agree that these are nice to have then we can add similar functions for the mouse.