### PR TITLE
Split performStream into functions handling stream of futures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "node"
-  - "8"
 
 after_success:
   - "npm run codecov"

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -3,7 +3,12 @@ import { combine, isPlaceholder } from "./index";
 import { State, Reactive, Time, BListener, Parent, SListener } from "./common";
 import { Future, BehaviorFuture } from "./future";
 import * as F from "./future";
-import { Stream } from "./stream";
+import {
+  Stream,
+  FlatFutureOrdered,
+  FlatFutureLatest,
+  FlatFuture
+} from "./stream";
 import { tick, getTime } from "./clock";
 import { sample, Now } from "./now";
 
@@ -746,4 +751,30 @@ export function format(
   ...behaviors: Array<string | number | Behavior<string | number>>
 ): Behavior<string> {
   return new FormatBehavior(strings, behaviors);
+}
+
+export const flatFutureFrom = <A>(
+  stream: Stream<Future<A>>
+): Behavior<Stream<A>> => fromFunction(() => new FlatFuture(stream));
+
+export function flatFuture<A>(stream: Stream<Future<A>>): Now<Stream<A>> {
+  return sample(flatFutureFrom(stream));
+}
+
+export const flatFutureOrderedFrom = <A>(
+  stream: Stream<Future<A>>
+): Behavior<Stream<A>> => fromFunction(() => new FlatFutureOrdered(stream));
+
+export function flatFutureOrdered<A>(
+  stream: Stream<Future<A>>
+): Now<Stream<A>> {
+  return sample(flatFutureOrderedFrom(stream));
+}
+
+export const flatFutureLatestFrom = <A>(
+  stream: Stream<Future<A>>
+): Behavior<Stream<A>> => fromFunction(() => new FlatFutureLatest(stream));
+
+export function flatFutureLatest<A>(stream: Stream<Future<A>>): Now<Stream<A>> {
+  return sample(flatFutureLatestFrom(stream));
 }

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -5,9 +5,9 @@ import { Future, BehaviorFuture } from "./future";
 import * as F from "./future";
 import {
   Stream,
-  FlatFutureOrdered,
-  FlatFutureLatest,
-  FlatFuture
+  FlatFuturesOrdered,
+  FlatFuturesLatest,
+  FlatFutures
 } from "./stream";
 import { tick, getTime } from "./clock";
 import { sample, Now } from "./now";
@@ -753,28 +753,30 @@ export function format(
   return new FormatBehavior(strings, behaviors);
 }
 
-export const flatFutureFrom = <A>(
+export const flatFuturesFrom = <A>(
   stream: Stream<Future<A>>
-): Behavior<Stream<A>> => fromFunction(() => new FlatFuture(stream));
+): Behavior<Stream<A>> => fromFunction(() => new FlatFutures(stream));
 
-export function flatFuture<A>(stream: Stream<Future<A>>): Now<Stream<A>> {
-  return sample(flatFutureFrom(stream));
+export function flatFutures<A>(stream: Stream<Future<A>>): Now<Stream<A>> {
+  return sample(flatFuturesFrom(stream));
 }
 
-export const flatFutureOrderedFrom = <A>(
+export const flatFuturesOrderedFrom = <A>(
   stream: Stream<Future<A>>
-): Behavior<Stream<A>> => fromFunction(() => new FlatFutureOrdered(stream));
+): Behavior<Stream<A>> => fromFunction(() => new FlatFuturesOrdered(stream));
 
-export function flatFutureOrdered<A>(
+export function flatFuturesOrdered<A>(
   stream: Stream<Future<A>>
 ): Now<Stream<A>> {
-  return sample(flatFutureOrderedFrom(stream));
+  return sample(flatFuturesOrderedFrom(stream));
 }
 
-export const flatFutureLatestFrom = <A>(
+export const flatFuturesLatestFrom = <A>(
   stream: Stream<Future<A>>
-): Behavior<Stream<A>> => fromFunction(() => new FlatFutureLatest(stream));
+): Behavior<Stream<A>> => fromFunction(() => new FlatFuturesLatest(stream));
 
-export function flatFutureLatest<A>(stream: Stream<Future<A>>): Now<Stream<A>> {
-  return sample(flatFutureLatestFrom(stream));
+export function flatFuturesLatest<A>(
+  stream: Stream<Future<A>>
+): Now<Stream<A>> {
+  return sample(flatFuturesLatestFrom(stream));
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -479,7 +479,7 @@ export function mapCbStream<A, B>(
   return new PerformCbStream(cb, stream);
 }
 
-export class FlatFuture<A> extends Stream<A> {
+export class FlatFutures<A> extends Stream<A> {
   constructor(stream: Stream<Future<A>>) {
     super();
     this.parents = cons(stream);
@@ -489,7 +489,7 @@ export class FlatFuture<A> extends Stream<A> {
   }
 }
 
-export class FlatFutureOrdered<A> extends Stream<A> {
+export class FlatFuturesOrdered<A> extends Stream<A> {
   constructor(stream: Stream<Future<A>>) {
     super();
     this.parents = cons(stream);
@@ -518,7 +518,7 @@ export class FlatFutureOrdered<A> extends Stream<A> {
   }
 }
 
-export class FlatFutureLatest<A> extends Stream<A>
+export class FlatFuturesLatest<A> extends Stream<A>
   implements SListener<Future<A>> {
   constructor(stream: Stream<Future<A>>) {
     super();

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -10,7 +10,8 @@ import {
   accum
 } from "./behavior";
 import { tick } from "./clock";
-import { Now, sample } from "./now";
+import { Now, sample, perform } from "./now";
+import { Future } from ".";
 
 /**
  * A stream is a list of occurrences over time. Each occurrence
@@ -476,4 +477,71 @@ export function mapCbStream<A, B>(
   stream: Stream<A>
 ): Stream<B> {
   return new PerformCbStream(cb, stream);
+}
+
+export class FlatFuture<A> extends Stream<A> {
+  constructor(stream: Stream<Future<A>>) {
+    super();
+    this.parents = cons(stream);
+  }
+  pushS(_t: number, fut: Future<A>): void {
+    fut.subscribe((a) => this.pushSToChildren(tick(), a));
+  }
+}
+
+export class FlatFutureOrdered<A> extends Stream<A> {
+  constructor(stream: Stream<Future<A>>) {
+    super();
+    this.parents = cons(stream);
+  }
+  nextId: number = 0;
+  next: number = 0;
+  buffer: { value: A }[] = []; // Object-wrapper to support a result as undefined
+  pushS(_t: number, fut: Future<A>): void {
+    const id = this.nextId++;
+    fut.subscribe((a: A) => {
+      if (id === this.next) {
+        this.buffer[0] = { value: a };
+        this.pushFromBuffer();
+      } else {
+        this.buffer[id - this.next] = { value: a };
+      }
+    });
+  }
+  pushFromBuffer(): void {
+    while (this.buffer[0] !== undefined) {
+      const t = tick();
+      const { value } = this.buffer.shift();
+      this.pushSToChildren(t, value);
+      this.next++;
+    }
+  }
+}
+
+export class FlatFutureLatest<A> extends Stream<A>
+  implements SListener<Future<A>> {
+  constructor(stream: Stream<Future<A>>) {
+    super();
+    this.parents = cons(stream);
+  }
+  next: number = 0;
+  newest: number = 0;
+  running: number = 0;
+  pushS(_t: number, fut: Future<A>): void {
+    const time = ++this.next;
+    this.running++;
+    fut.subscribe((a: A) => {
+      this.running--;
+      if (time > this.newest) {
+        const t = tick();
+        if (this.running === 0) {
+          this.next = 0;
+          this.newest = 0;
+        } else {
+          this.newest = time;
+        }
+        this.pushSToChildren(t, a);
+      }
+    });
+  }
 }

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -9,9 +9,9 @@ import {
   CombineStream,
   SnapshotStream,
   isStream,
-  FlatFuture,
-  FlatFutureOrdered,
-  FlatFutureLatest
+  FlatFutures,
+  FlatFuturesOrdered,
+  FlatFuturesLatest
 } from "./stream";
 import {
   Behavior,
@@ -224,14 +224,14 @@ const flatFuture = <A>(o: Occurrence<Future<A>>) => {
   return time === "infinity" ? [] : [{ time: Math.max(o.time, time), value }];
 };
 
-FlatFuture.prototype.model = function<A>(this: FlatFuture<A>) {
+FlatFutures.prototype.model = function<A>(this: FlatFutures<A>) {
   return (this.parents.value as Stream<Future<A>>)
     .model()
     .flatMap(flatFuture)
     .sort((o, p) => o.time - p.time); // FIXME: Should use stable sort here
 };
 
-FlatFutureOrdered.prototype.model = function<A>(this: FlatFutureOrdered<A>) {
+FlatFuturesOrdered.prototype.model = function<A>(this: FlatFuturesOrdered<A>) {
   return (this.parents.value as Stream<Future<A>>)
     .model()
     .flatMap(flatFuture)
@@ -241,7 +241,7 @@ FlatFutureOrdered.prototype.model = function<A>(this: FlatFutureOrdered<A>) {
     }, []);
 };
 
-FlatFutureLatest.prototype.model = function<A>(this: FlatFutureLatest<A>) {
+FlatFuturesLatest.prototype.model = function<A>(this: FlatFuturesLatest<A>) {
   return (this.parents.value as Stream<Future<A>>)
     .model()
     .flatMap(flatFuture)

--- a/test/now.ts
+++ b/test/now.ts
@@ -19,8 +19,7 @@ import {
   SinkStream,
   time,
   toPromise,
-  instant,
-  flatFuture
+  instant
 } from "../src";
 import * as H from "../src";
 import { createRef, mutateRef } from "./helpers";
@@ -196,7 +195,7 @@ describe("Now", () => {
       });
       const s = sinkStream();
       const mappedS = s.map(impure);
-      runNow(performStream(mappedS).flatMap(flatFuture)).subscribe((n) =>
+      runNow(performStream(mappedS).flatMap(H.flatFutures)).subscribe((n) =>
         results.push(n)
       );
       s.push(1);

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -6,7 +6,6 @@ import {
   Behavior,
   fromFunction,
   sinkBehavior,
-  sinkStream,
   Future
 } from "../src";
 import * as H from "../src";
@@ -514,7 +513,7 @@ describe("stream", () => {
       const fut2 = H.sinkFuture<number>();
       const fut3 = H.sinkFuture<number>();
       const s = H.sinkStream<Future<number>>();
-      const s2 = H.runNow(H.flatFuture(s));
+      const s2 = H.runNow(H.flatFutures(s));
       const sub = subscribeSpy(s2);
       s.push(fut1);
       s.push(fut2);
@@ -529,7 +528,7 @@ describe("stream", () => {
       const fut2 = H.sinkFuture<number>();
       const fut3 = H.sinkFuture<number>();
       const s = H.sinkStream<Future<number>>();
-      const s2 = H.runNow(H.flatFutureOrdered(s));
+      const s2 = H.runNow(H.flatFuturesOrdered(s));
       const sub = subscribeSpy(s2);
       s.push(fut1);
       s.push(fut2);
@@ -544,7 +543,7 @@ describe("stream", () => {
       const fut2 = H.sinkFuture<number>();
       const fut3 = H.sinkFuture<number>();
       const s = H.sinkStream<Future<number>>();
-      const s2 = H.runNow(H.flatFutureLatest(s));
+      const s2 = H.runNow(H.flatFuturesLatest(s));
       const sub = subscribeSpy(s2);
       s.push(fut1);
       s.push(fut2);

--- a/test/testing.ts
+++ b/test/testing.ts
@@ -208,7 +208,7 @@ describe("testing", () => {
         assertStreamEqual(res, { 4: 1, 5: 1, 7: 2, 9: 3, 10: 1 });
       });
     });
-    describe("flatFuture", () => {
+    describe("flatFutures", () => {
       it("can be tested", () => {
         const s = testStreamFromObject({
           0: testFuture(1, "a"),
@@ -216,7 +216,7 @@ describe("testing", () => {
           4: testFuture(2, "c"),
           6: testFuture(7, "d")
         });
-        const res = testNow(H.flatFuture(s), []);
+        const res = testNow(H.flatFutures(s), []);
         assert(H.isStream(res));
         assertStreamEqual(
           res,
@@ -224,7 +224,7 @@ describe("testing", () => {
         );
       });
     });
-    describe("flatFutureLatest", () => {
+    describe("flatFuturesLatest", () => {
       it("can be tested", () => {
         const s = testStreamFromObject({
           0: testFuture(1, "a"),
@@ -234,7 +234,7 @@ describe("testing", () => {
           8: testFuture(12, "e"), // should be dropped
           10: testFuture(3, "f")
         });
-        const res = testNow(H.flatFutureLatest(s), []);
+        const res = testNow(H.flatFuturesLatest(s), []);
         assert(H.isStream(res));
         assertStreamEqual(
           res,
@@ -242,7 +242,7 @@ describe("testing", () => {
         );
       });
     });
-    describe("flatFutureOrdered", () => {
+    describe("flatFuturesOrdered", () => {
       it("can be tested", () => {
         const s = testStreamFromObject({
           0: testFuture(3, "a"),
@@ -251,7 +251,7 @@ describe("testing", () => {
           3: testFuture(0, "d"),
           4: testFuture(5, "e")
         });
-        const res = testNow(H.flatFutureOrdered(s), []);
+        const res = testNow(H.flatFuturesOrdered(s), []);
         assert(H.isStream(res));
         assertStreamEqual(
           res,
@@ -379,7 +379,7 @@ describe("testing", () => {
           );
           const response: Stream<string> = yield H.performStream(
             request
-          ).flatMap(H.flatFutureOrdered);
+          ).flatMap(H.flatFuturesOrdered);
           return { res: response };
         });
         const click = testStreamFromObject({ 1: 1, 2: 2, 3: 3, 4: 4, 5: 5 });
@@ -410,7 +410,7 @@ describe("testing", () => {
               })
             );
             const res = run(
-              H.performStream(request).flatMap(H.flatFutureOrdered)
+              H.performStream(request).flatMap(H.flatFuturesOrdered)
             );
             return { res };
           });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,10 +10,8 @@
     "lib": [
       "dom",
       "es5",
-      "es2015.core",
-      "es2015.promise",
-      "es2015.iterable",
-      "es2015.proxy"
+      "es2015",
+      "es2019"
     ]
   },
   "include": ["src/**/*", "test/**/*"],


### PR DESCRIPTION
This PR changes

```ts
function performStream<A>(s: Stream<IO<A>>): Now<Stream<A>>;
function performStreamLatest<A>(s: Stream<IO<A>>): Now<Stream<A>>;
function performStreamOrdered<A>(s: Stream<IO<A>>): Now<Stream<A>>;
```

into

```ts
function performStream<A>(s: Stream<IO<A>>): Now<Stream<Future<A>>>;

function flatFuture<A>(stream: Stream<Future<A>>): Now<Stream<A>>;
function flatFutureLatest<A>(stream: Stream<Future<A>>): Now<Stream<A>>;
function flatFutureOrdered<A>;
```

In other words, there is now a single function for running a stream and it results in a stream of futures. To flatten/unnest this stream of futures one then has to use one of the three new functions for doing so. But, these new functions can be used in any circumstance where one has a stream of futures.

We can discuss the names of the last three function. The logic behind the current names is that `flat` is a function that turns `M<M<A>>` into `M<A>` while satisfying things like `flat(map(v => M.of(v)) === v` and the new functions are similar in that `flatFuture` turns a `Stream<Future<A>>` into a `Stream<A>` while satisfying things like `flatFuture(map(v => Future.of(v), stream)) === stream`. Hence the idea is that highlighting the similarity by using a familiar word "flat" will make it easier to understand and remember what this new function does.

Related to: https://github.com/funkia/purescript-hareactive/issues/3