### PR TITLE
refactor: replace any with unknown, enable noImplicitAny

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ behaviors it depends on. To understand this, consider the following contrived
 example.
 
 ```js
-const lifted = lift((a, b, c, d) => a && b ? c : d, aB, bB, cB, dB);
+const lifted = lift((a, b, c, d) => (a && b ? c : d), aB, bB, cB, dB);
 ```
 
 Here the resulting behavior will _always_ depend on both `aB`, `bB`, `cB`,
@@ -725,7 +725,7 @@ it is just a "black box".
 If, on the other hand, we use `moment`:
 
 ```js
-const momented = moment((at) => at(aB) && at(bB) ? at(cB) : at(dB));
+const momented = moment((at) => (at(aB) && at(bB) ? at(cB) : at(dB)));
 ```
 
 Then `moment` can simply check which behaviors are actually sampled inside the
@@ -736,8 +736,7 @@ depends on `atB` and there is no need to recompute `momented` when any of the
 other behaviors changes.
 
 `moment` can also be very useful with behaviors nested inside behaviors. If
-`persons` is a behavior of an array of persons and is of the type `Behavior<{
-age: Behavior<number>, name: string }[]>` then the following code creates a
+`persons` is a behavior of an array of persons and is of the type `Behavior<{ age: Behavior<number>, name: string }[]>` then the following code creates a
 behavior that at any time is equal to the name of the first person in the array
 whose age is greater than 20.
 

--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -30,7 +30,7 @@ export abstract class Behavior<A> extends Reactive<A, BListener>
   constructor() {
     super();
   }
-  static is(a: any): a is Behavior<any> {
+  static is(a: unknown): a is Behavior<unknown> {
     return isBehavior(a);
   }
   map<B>(fn: (a: A) => B): Behavior<B> {
@@ -48,7 +48,7 @@ export abstract class Behavior<A> extends Reactive<A, BListener>
   ap<B>(f: Behavior<(a: A) => B>): Behavior<B> {
     return new ApBehavior<A, B>(f, this);
   }
-  lift<A extends any[], R>(
+  lift<A extends unknown[], R>(
     f: (...args: A) => R,
     ...args: MapBehaviorTuple<A>
   ): Behavior<R> {
@@ -122,7 +122,7 @@ export abstract class Behavior<A> extends Reactive<A, BListener>
   }
 }
 
-export function pushToChildren(t: number, b: Behavior<any>): void {
+export function pushToChildren(t: number, b: Behavior<unknown>): void {
   for (const child of b.children) {
     child.pushB(t);
   }
@@ -137,7 +137,7 @@ function refresh<A>(b: Behavior<A>, t: number) {
   b.last = newValue;
 }
 
-export function isBehavior(b: any): b is Behavior<any> {
+export function isBehavior<A>(b: unknown): b is Behavior<A> {
   return (
     (typeof b === "object" && "at" in b && !isPlaceholder(b)) ||
     (isPlaceholder(b) && (b.source === undefined || isBehavior(b.source)))
@@ -238,7 +238,7 @@ export function at<B>(b: Behavior<B>, t?: number): B {
 }
 
 export class MapBehavior<A, B> extends Behavior<B> {
-  constructor(private parent: Behavior<any>, private f: (a: A) => B) {
+  constructor(private parent: Behavior<A>, private f: (a: A) => B) {
     super();
     this.parents = cons(parent);
   }
@@ -250,7 +250,7 @@ export class MapBehavior<A, B> extends Behavior<B> {
 class ApBehavior<A, B> extends Behavior<B> {
   constructor(private fn: Behavior<(a: A) => B>, private val: Behavior<A>) {
     super();
-    this.parents = cons<any>(fn, cons(val));
+    this.parents = cons<Behavior<((a: A) => B) | A>>(fn, cons(val));
   }
   update(_t: number): B {
     return this.fn.last(this.val.last);
@@ -271,7 +271,7 @@ export function ap<A, B>(
   return valB.ap(fnB);
 }
 
-export class LiftBehavior<A extends any[], R> extends Behavior<R> {
+export class LiftBehavior<A extends unknown[], R> extends Behavior<R> {
   constructor(private f: (...as: A) => R, private bs: MapBehaviorTuple<A>) {
     super();
     this.parents = fromArray(bs);
@@ -344,7 +344,7 @@ export function when(b: Behavior<boolean>): Now<Future<{}>> {
 
 class SnapshotBehavior<A> extends Behavior<Future<A>> implements SListener<A> {
   private node: Node<this> = new Node(this);
-  constructor(private parent: Behavior<A>, private future: Future<any>) {
+  constructor(private parent: Behavior<A>, private future: Future<unknown>) {
     super();
     if (future.state === State.Done) {
       // Future has occurred at some point in the past
@@ -375,7 +375,7 @@ class SnapshotBehavior<A> extends Behavior<Future<A>> implements SListener<A> {
 
 export function snapshotAt<A>(
   b: Behavior<A>,
-  f: Future<any>
+  f: Future<unknown>
 ): Behavior<Future<A>> {
   return new SnapshotBehavior(b, f);
 }
@@ -505,14 +505,14 @@ export function freezeTo<A>(
 
 export function freezeAtFrom<A>(
   behavior: Behavior<A>,
-  shouldFreeze: Future<any>
+  shouldFreeze: Future<unknown>
 ): Behavior<Behavior<A>> {
   return snapshotAt(behavior, shouldFreeze).map((f) => freezeTo(behavior, f));
 }
 
 export function freezeAt<A>(
   behavior: Behavior<A>,
-  shouldFreeze: Future<any>
+  shouldFreeze: Future<unknown>
 ): Now<Behavior<A>> {
   return sample(freezeAtFrom(behavior, shouldFreeze));
 }
@@ -583,7 +583,7 @@ export function accum<A, B>(
   return sample(accumFrom(f, initial, source));
 }
 
-export type AccumPair<A> = [Stream<any>, (a: any, b: A) => A];
+export type AccumPair<A> = [Stream<unknown>, (a: unknown, b: A) => A];
 
 function accumPairToApp<A>([stream, fn]: AccumPair<A>): Stream<(a: A) => A> {
   return stream.map((a) => (b: A) => fn(a, b));
@@ -607,7 +607,7 @@ export function accumCombine<B>(
   return sample(accumCombineFrom(pairs, initial));
 }
 
-const firstArg = <A>(a: A, _: any): A => a;
+const firstArg = <A>(a: A, _: unknown): A => a;
 
 /**
  * Creates a Behavior whose value is the last occurrence in the stream.
@@ -638,8 +638,8 @@ export function stepper<B>(initial: B, steps: Stream<B>): Now<Behavior<B>> {
  */
 export function toggleFrom(
   initial: boolean,
-  turnOn: Stream<any>,
-  turnOff: Stream<any>
+  turnOn: Stream<unknown>,
+  turnOff: Stream<unknown>
 ): Behavior<Behavior<boolean>> {
   return stepperFrom(initial, turnOn.mapTo(true).combine(turnOff.mapTo(false)));
 }
@@ -652,8 +652,8 @@ export function toggleFrom(
  */
 export function toggle(
   initial: boolean,
-  turnOn: Stream<any>,
-  turnOff: Stream<any>
+  turnOn: Stream<unknown>,
+  turnOff: Stream<unknown>
 ): Now<Behavior<boolean>> {
   return sample(toggleFrom(initial, turnOn, turnOff));
 }

--- a/src/datastructures.ts
+++ b/src/datastructures.ts
@@ -14,7 +14,7 @@ export class Cons<A> {
   }
 }
 
-export const nil: Cons<any> = new Cons(undefined, undefined, true);
+export const nil: Cons<undefined> = new Cons(undefined, undefined, true);
 
 export function cons<A>(value: A, tail: Cons<A> = nil): Cons<A> {
   return new Cons(value, tail, false);

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -12,7 +12,7 @@ class DomEventStream<A> extends ProducerStream<A> {
   constructor(
     private target: EventTarget,
     private eventName: string,
-    private extractor: Extractor<any, EventTarget, A>
+    private extractor: Extractor<unknown, EventTarget, A>
   ) {
     super();
   }
@@ -61,12 +61,12 @@ export function streamFromEvent<
 export function streamFromEvent<A>(
   target: EventTarget,
   eventName: string,
-  extractor: Extractor<any, EventTarget, A>
+  extractor: Extractor<unknown, EventTarget, A>
 ): Stream<A>;
 export function streamFromEvent<A>(
   target: EventTarget,
   eventName: string,
-  extractor: Extractor<any, EventTarget, A> = id
+  extractor: Extractor<A, EventTarget, A> = id
 ): Stream<A> {
   return new DomEventStream(target, eventName, extractor);
 }
@@ -76,7 +76,7 @@ class DomEventBehavior<A> extends ProducerBehavior<A> {
     private target: EventTarget,
     private eventName: string,
     private getter: (t: EventTarget) => A,
-    private extractor: Extractor<any, EventTarget, A>
+    private extractor: Extractor<unknown, EventTarget, A>
   ) {
     super();
     this.last = getter(target);
@@ -123,13 +123,13 @@ export function behaviorFromEvent<A>(
   target: EventTarget,
   eventName: string,
   getter: (t: EventTarget) => A,
-  extractor: Extractor<any, EventTarget, A>
+  extractor: Extractor<unknown, EventTarget, A>
 ): Behavior<A>;
 export function behaviorFromEvent<A>(
   target: EventTarget,
   eventName: string,
   getter: (t: EventTarget) => A,
-  extractor: Extractor<any, EventTarget, A>
+  extractor: Extractor<unknown, EventTarget, A>
 ): Behavior<A> {
   return new DomEventBehavior(target, eventName, getter, extractor);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,10 @@ export * from "./placeholder";
 export * from "./animation";
 export * from "./clock";
 
+export interface UnknownMappable<A> {
+  readonly map: <B>(f: (a: A) => B) => UnknownMappable<B>;
+}
+
 /**
  * Map a function over a behavior or stream. This means that if at some point in
  * time the value of `b` is `bVal` then the value of the returned
@@ -22,7 +26,10 @@ export function map<A, B>(fn: (a: A) => B, future: Future<A>): Future<B>;
 export function map<A, B>(fn: (a: A) => B, stream: Stream<A>): Stream<B>;
 export function map<A, B>(fn: (a: A) => B, behavior: Behavior<A>): Behavior<B>;
 export function map<A, B>(fn: (a: A) => B, behavior: Now<A>): Now<B>;
-export function map<A, B>(fn: (a: A) => B, b: any): any {
+export function map<A, B>(
+  fn: (a: A) => B,
+  b: UnknownMappable<A>
+): UnknownMappable<B> {
   return b.map(fn);
 }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -18,7 +18,7 @@ import { Future } from ".";
  * happens at a point in time and has an associated value.
  */
 export abstract class Stream<A> extends Reactive<A, SListener<A>>
-  implements Parent<SListener<any>> {
+  implements Parent<SListener<unknown>> {
   constructor() {
     super();
   }
@@ -54,8 +54,8 @@ export abstract class Stream<A> extends Reactive<A, SListener<A>>
     );
     return this;
   }
-  abstract pushS(t: number, value: any): void;
-  pushSToChildren(t: number, value: any): void {
+  abstract pushS(t: number, value: unknown): void;
+  pushSToChildren(t: number, value: A): void {
     for (const child of this.children) {
       child.pushS(t, value);
     }
@@ -146,12 +146,12 @@ export abstract class ActiveStream<A> extends Stream<A> {
   deactivate(): void {}
 }
 
-class EmptyStream extends ActiveStream<any> {
+class EmptyStream extends ActiveStream<unknown> {
   constructor() {
     super();
   }
   /* istanbul ignore next */
-  pushS(_t: number): void {
+  pushS(): void {
     throw new Error("You cannot push to an empty stream");
   }
 }
@@ -378,11 +378,11 @@ export function subscribe<A>(fn: (a: A) => void, stream: Stream<A>): void {
 
 export class SnapshotStream<B> extends Stream<B> {
   private node: Node<this> = new Node(this);
-  constructor(readonly target: Behavior<B>, readonly trigger: Stream<any>) {
+  constructor(readonly target: Behavior<B>, readonly trigger: Stream<unknown>) {
     super();
     this.parents = cons(trigger);
   }
-  pushS(t: number, _: any): void {
+  pushS(t: Time): void {
     const b = this.target.at(t);
     this.pushSToChildren(t, b);
   }
@@ -396,7 +396,7 @@ export class SnapshotStream<B> extends Stream<B> {
 
 export function snapshot<B>(
   target: Behavior<B>,
-  trigger: Stream<any>
+  trigger: Stream<unknown>
 ): Stream<B> {
   return new SnapshotStream(target, trigger);
 }
@@ -447,7 +447,7 @@ export function selfie<A>(stream: Stream<Behavior<A>>): Stream<A> {
   return new SelfieStream(stream);
 }
 
-export function isStream(s: any): s is Stream<any> {
+export function isStream(s: unknown): s is Stream<unknown> {
   return typeof s === "object" && "scanFrom" in s;
 }
 
@@ -461,7 +461,7 @@ class PerformCbStream<A, B> extends ActiveStream<B> implements SListener<A> {
     super();
     stream.addListener(this.node, tick());
   }
-  pushS(_: number, value: A): void {
+  pushS(_: Time, value: A): void {
     this.cb(value, this.doneCb);
   }
 }

--- a/src/time.ts
+++ b/src/time.ts
@@ -49,7 +49,7 @@ class DebounceStream<A> extends Stream<A> {
     super();
     this.parents = cons(parent);
   }
-  private timer: any = undefined;
+  private timer: NodeJS.Timeout | undefined = undefined;
   pushS(t: number, a: A): void {
     clearTimeout(this.timer);
     this.timer = setTimeout(() => {

--- a/test/behavior.ts
+++ b/test/behavior.ts
@@ -17,7 +17,8 @@ import {
   freezeTo,
   Stream,
   time,
-  runNow
+  runNow,
+  Time
 } from "../src";
 
 import * as H from "../src";
@@ -94,8 +95,8 @@ describe("behavior", () => {
     });
     it("can push and pull", () => {
       let variable = 0;
-      let push = undefined;
-      const setVar = (n) => {
+      let push: (t: Time) => void;
+      const setVar = (n: number) => {
         variable = n;
         if (push !== undefined) {
           push(n);
@@ -166,7 +167,7 @@ describe("behavior", () => {
         assert.strictEqual(at(b, 1), 3);
         const mapped = map(double, b);
         let a;
-        mapped.observe((v) => (a = v), () => {});
+        mapped.observe((v: unknown) => (a = v), () => {});
         assert.strictEqual(a, 6);
       });
       it("maps constant function", () => {
@@ -186,7 +187,7 @@ describe("behavior", () => {
         });
         const mapped = map(double, b);
         const cb = spy();
-        mapped.observe(cb, (pull) => {
+        mapped.observe(cb, (pull: (t: Time) => void) => {
           pull(1);
           time = 1;
           pull(2);
@@ -418,7 +419,7 @@ describe("behavior", () => {
       const pushSpy = spy();
       const beginPullingSpy = spy();
       const endPullingSpy = spy();
-      const handlePulling = (...args) => {
+      const handlePulling = (...args: unknown[]) => {
         beginPullingSpy(...args);
         return endPullingSpy;
       };
@@ -676,7 +677,7 @@ describe("Behavior and Future", () => {
       const pushSpy = spy();
       const beginPullingSpy = spy();
       const endPullingSpy = spy();
-      const handlePulling = (...args) => {
+      const handlePulling = (...args: unknown[]) => {
         beginPullingSpy(...args);
         return endPullingSpy;
       };
@@ -935,7 +936,7 @@ describe("Behavior and Stream", () => {
       const flattened = H.flat(outer);
       const pushSpy = spy();
       let pull: () => void;
-      const handlePulling = (p) => {
+      const handlePulling = (p: () => void): (() => void) => {
         pull = p;
         return () => undefined;
       };
@@ -953,7 +954,7 @@ describe("Behavior and Stream", () => {
   describe("log", () => {
     it("logs every change on push behavior", () => {
       const origLog = console.log;
-      const strings = [];
+      const strings: unknown[] = [];
       console.log = (...s: string[]) => strings.push(s);
       const b = sinkBehavior("hello");
       b.log();
@@ -963,7 +964,7 @@ describe("Behavior and Stream", () => {
     });
     it("logs with prefix", () => {
       const origLog = console.log;
-      const strings = [];
+      const strings: unknown[] = [];
       console.log = (...s: string[]) => strings.push(s);
       const b = sinkBehavior("hello");
       b.log("b");
@@ -974,7 +975,7 @@ describe("Behavior and Stream", () => {
     it("logs on pull behavior", () => {
       const clock = useFakeTimers();
       const origLog = console.log;
-      const strings = [];
+      const strings: unknown[] = [];
       console.log = (...s: string[]) => strings.push(s);
 
       let v = "zero";

--- a/test/dom.ts
+++ b/test/dom.ts
@@ -26,11 +26,15 @@ describe("dom", () => {
 
     it("applies extractor to event", () => {
       const input = document.createElement("input");
+      interface Result {
+        readonly bubbles: boolean;
+        readonly value: string;
+      }
       const s = streamFromEvent(input, "input", (e, elm) => ({
         bubbles: e.bubbles,
         value: elm.value
       }));
-      const result = [];
+      const result: Result[] = [];
       s.subscribe((ev) => result.push(ev));
       const event = new Event("input");
       input.dispatchEvent(event);
@@ -50,7 +54,7 @@ describe("dom", () => {
         (elm) => elm.value,
         (evt, elm) => elm.value
       );
-      const result = [];
+      const result: string[] = [];
       s.subscribe((ev) => result.push(ev));
       assert.strictEqual(result.length, 1);
       assert.strictEqual(result[0], "initial");
@@ -64,7 +68,7 @@ describe("dom", () => {
         (elm) => elm.value,
         (evt, elm) => elm.value
       );
-      const result = [];
+      const result: string[] = [];
       s.subscribe((ev) => result.push(ev));
       // simulate input low latency
       input.value = "second";
@@ -80,7 +84,7 @@ describe("dom", () => {
         (elm) => elm.value,
         (_evt, elm) => elm.value
       );
-      const result = [];
+      const result: string[] = [];
       const sink = H.sinkStream<number>();
       // We snapshot the behaviors without activating it
       const s = H.snapshot(b, sink);

--- a/test/now.ts
+++ b/test/now.ts
@@ -234,7 +234,7 @@ describe("Now", () => {
   });
   describe("loopNow", () => {
     it("should loop the reactives", () => {
-      const result = [];
+      const result: unknown[] = [];
       let s: SinkStream<string>;
       const now = loopNow(({ stream }) => {
         stream.subscribe((a) => result.push(a));
@@ -249,7 +249,7 @@ describe("Now", () => {
       assert.deepEqual(result, ["a", "b", "c"]);
     });
     it("should return the reactives", () => {
-      const result = [];
+      const result: unknown[] = [];
       let s: SinkStream<string>;
       const now = loopNow(({ stream }) => {
         stream.subscribe((a) => a);

--- a/test/placeholder.ts
+++ b/test/placeholder.ts
@@ -83,10 +83,10 @@ describe("placeholder", () => {
       let variable = 0;
       const b = fromFunction(() => variable);
       const p = placeholder<number>();
-      const mapResult = [];
+      const mapResult: unknown[] = [];
       const pm = p.map((n) => (mapResult.push(n), n));
       const result: Array<number> = [];
-      let pull;
+      let pull: (t?: number) => void;
       observe(
         (a) => {
           result.push(a);
@@ -191,8 +191,8 @@ describe("placeholder", () => {
       const sum = H.placeholder<number>();
       const change = sum.map((_) => 1);
       const sum2 = H.at(H.switcherFrom(H.at(H.integrateFrom(change)), H.empty));
-      const results = [];
-      let pull;
+      const results: unknown[] = [];
+      let pull: () => void;
       observe(
         (n: number) => results.push(n),
         (p) => {

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -421,7 +421,7 @@ describe("stream", () => {
   describe("log", () => {
     it("logs every value", () => {
       const origLog = console.log;
-      const strings = [];
+      const strings: string[][] = [];
       console.log = (...s: string[]) => strings.push(s);
       const s = H.sinkStream();
       s.log();
@@ -433,7 +433,7 @@ describe("stream", () => {
     });
     it("logs with prefix", () => {
       const origLog = console.log;
-      const strings = [];
+      const strings: string[][] = [];
       console.log = (...s: string[]) => strings.push(s);
       const s = H.sinkStream();
       s.log("s");

--- a/test/time.ts
+++ b/test/time.ts
@@ -78,7 +78,7 @@ describe("behavior", () => {
         setTime(3);
         const time = H.runNow(H.measureTime);
         let pull: (t?: number) => void;
-        const results = [];
+        const results: number[] = [];
         H.observe(
           (n: number) => {
             results.push(n);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,17 +2,12 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "experimentalDecorators": true,
     "importHelpers": true,
     "sourceMap": true,
     "skipLibCheck": true,
-    "lib": [
-      "dom",
-      "es5",
-      "es2015",
-      "es2019"
-    ]
+    "lib": ["dom", "es5", "es2015", "es2019"]
   },
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Hi!
First, thanks for this lib, I've spent quite a lot of time searching for something similar to hareactive and now looks like I have what I need, thanks!

In the meantime, while I'm wrapping my head around the actual implementation, I'd like to contribute to type-safety of the code.

So, in this PR I
 - tried to remove `any` type annotations and casts `as any` as much as possible. I failed in some places because couldn't get how they work :)
 - enabled `noImplicitAny` and made corresponding changes to the code

Although all changes in this PR are cosmetical and the logic isn't changed, there _may_ be some breaking changes due to using more strict `unknown` type instead of `any` in some public API.