### PR TITLE
Strict function types

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/coverage
+/dist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     "@typescript-eslint/ban-ts-ignore": "off",
     "@typescript-eslint/no-this-alias": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-empty-function": "off"
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-non-null-assertion": "error"
   }
 };

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -12,7 +12,7 @@ class DomEventStream<A> extends ProducerStream<A> {
   constructor(
     private target: EventTarget,
     private eventName: string,
-    private extractor: Extractor<unknown, EventTarget, A>
+    private extractor: Extractor<Event, EventTarget, A>
   ) {
     super();
   }
@@ -66,8 +66,8 @@ export function streamFromEvent<A>(
 export function streamFromEvent<A>(
   target: EventTarget,
   eventName: string,
-  extractor: Extractor<A, EventTarget, A> = id
-): Stream<A> {
+  extractor: Extractor<Event, EventTarget, Event> = id
+): Stream<Event> {
   return new DomEventStream(target, eventName, extractor);
 }
 

--- a/src/future.ts
+++ b/src/future.ts
@@ -1,13 +1,23 @@
-import { State, SListener, Parent, BListener, Time } from "./common";
+import { State, SListener, Parent, BListener, Time, __UNSAFE_GET_LAST_BEHAVIOR_VALUE } from "./common";
 import { Reactive } from "./common";
 import { cons, fromArray, Node } from "./datastructures";
-import { Behavior, FunctionBehavior } from "./behavior";
+import {
+  Behavior,
+  FunctionBehavior
+} from "./behavior";
 import { tick } from "./clock";
 import { Stream } from "./stream";
 import { sample, Now } from "./now";
 
 export type MapFutureTuple<A> = { [K in keyof A]: Future<A[K]> };
 
+const __UNSAFE_GET_LAST_FUTURE_VALUE = <A>(f: Future<A>): A => {
+  if (f.value === undefined) {
+    // panic!
+    throw new Error("Future#value should be defined");
+  }
+  return f.value;
+};
 /**
  * A future is a thing that occurs at some point in time with a value.
  * It can be understood as a pair consisting of the time the future
@@ -17,7 +27,7 @@ export type MapFutureTuple<A> = { [K in keyof A]: Future<A[K]> };
 export abstract class Future<A> extends Reactive<A, SListener<A>>
   implements Parent<SListener<unknown>> {
   // The value of the future. Often `undefined` until occurrence.
-  value: A;
+  value?: A;
   constructor() {
     super();
   }
@@ -37,7 +47,7 @@ export abstract class Future<A> extends Reactive<A, SListener<A>>
   }
   addListener(node: Node<SListener<A>>, t: number): State {
     if (this.state === State.Done) {
-      node.value.pushS(t, this.value);
+      node.value.pushS(t, __UNSAFE_GET_LAST_FUTURE_VALUE(this));
       return State.Done;
     } else {
       return super.addListener(node, t);
@@ -62,7 +72,7 @@ export abstract class Future<A> extends Reactive<A, SListener<A>>
   of<B>(b: B): Future<B> {
     return new OfFuture(b);
   }
-  ap: <B>(f: Future<(a: A) => B>) => Future<B>;
+  // ap: <B>(f: Future<(a: A) => B>) => Future<B>;
   lift<A extends unknown[], R>(
     f: (...args: A) => R,
     ...args: MapFutureTuple<A>
@@ -241,7 +251,7 @@ export class BehaviorFuture<A> extends SinkFuture<A> implements BListener {
   }
   pushB(t: number): void {
     this.b.removeListener(this.node);
-    this.resolve(this.b.last, t);
+    this.resolve(__UNSAFE_GET_LAST_BEHAVIOR_VALUE(this.b), t);
   }
 }
 

--- a/src/future.ts
+++ b/src/future.ts
@@ -88,7 +88,7 @@ export abstract class Future<A> extends Reactive<A, SListener<A>>
 }
 
 export function isFuture(a: unknown): a is Future<unknown> {
-  return typeof a === "object" && "resolve" in a;
+  return typeof a === "object" && a !== null && "resolve" in a;
 }
 
 export class CombineFuture<A> extends Future<A> {

--- a/src/future.ts
+++ b/src/future.ts
@@ -1,10 +1,14 @@
-import { State, SListener, Parent, BListener, Time, __UNSAFE_GET_LAST_BEHAVIOR_VALUE } from "./common";
+import {
+  State,
+  SListener,
+  Parent,
+  BListener,
+  Time,
+  __UNSAFE_GET_LAST_BEHAVIOR_VALUE
+} from "./common";
 import { Reactive } from "./common";
 import { cons, fromArray, Node } from "./datastructures";
-import {
-  Behavior,
-  FunctionBehavior
-} from "./behavior";
+import { Behavior, FunctionBehavior } from "./behavior";
 import { tick } from "./clock";
 import { Stream } from "./stream";
 import { sample, Now } from "./now";
@@ -62,7 +66,7 @@ export abstract class Future<A> extends Reactive<A, SListener<A>>
     return new MapFuture(f, this);
   }
   mapTo<B>(b: B): Future<B> {
-    return new MapToFuture<B>(b, this);
+    return new MapToFuture(b, this);
   }
   // A future is an applicative. `of` gives a future that has always
   // occurred at all points in time.
@@ -121,8 +125,8 @@ export class MapFuture<A, B> extends Future<B> {
   }
 }
 
-export class MapToFuture<A> extends Future<A> {
-  constructor(public value: A, readonly parent: Future<unknown>) {
+export class MapToFuture<A, _> extends Future<A> {
+  constructor(public value: A, readonly parent: Future<_>) {
     super();
     this.parents = cons(parent);
   }
@@ -266,7 +270,9 @@ export class NextOccurrenceFuture<A> extends Future<A> implements SListener<A> {
 }
 
 export function nextOccurrenceFrom<A>(stream: Stream<A>): Behavior<Future<A>> {
-  return new FunctionBehavior((t: Time) => new NextOccurrenceFuture(stream, t));
+  return new FunctionBehavior<Future<A>>(
+    (t: Time) => new NextOccurrenceFuture(stream, t)
+  );
 }
 
 export function nextOccurrence<A>(stream: Stream<A>): Now<Future<A>> {

--- a/src/now.ts
+++ b/src/now.ts
@@ -137,7 +137,7 @@ export class PerformMapNow<A, B> extends Now<Stream<B> | Future<B>> {
     super();
   }
   run(): Stream<B> | Future<B> {
-    return isStream(this.s)
+    return isStream<A>(this.s)
       ? mapCbStream((value, done) => done(this.cb(value)), this.s)
       : mapCbFuture((value, done) => done(this.cb(value)), this.s);
   }
@@ -153,7 +153,7 @@ export function performMap<A, B>(
   s: Stream<A> | Future<A>
 ): Now<Stream<B> | Future<B>> {
   return perform(() =>
-    isStream(s)
+    isStream<A>(s)
       ? mapCbStream((value, done) => done(cb(value)), s)
       : mapCbFuture((value, done) => done(cb(value)), s)
   );

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -1,5 +1,10 @@
-import { Reactive, State, SListener, BListener, Time } from "./common";
-import { Behavior, isBehavior, MapBehavior, pushToChildren } from "./behavior";
+import { Reactive, State, SListener, BListener, Time, __UNSAFE_GET_LAST_BEHAVIOR_VALUE } from "./common";
+import {
+  Behavior,
+  isBehavior,
+  MapBehavior,
+  pushToChildren
+} from "./behavior";
 import { Node, cons } from "./datastructures";
 import { Stream, MapToStream } from "./stream";
 import { tick } from "./clock";
@@ -14,7 +19,7 @@ class SamplePlaceholderError {
 }
 
 export class Placeholder<A> extends Behavior<A> {
-  source: Reactive<A, SListener<A> | BListener>;
+  source?: Reactive<A, SListener<A> | BListener>;
   private node: Node<this> = new Node(this);
   replaceWith(parent: Reactive<A, SListener<A> | BListener>, t?: Time): void {
     this.source = parent;
@@ -45,7 +50,7 @@ export class Placeholder<A> extends Behavior<A> {
     }
   }
   update(_t: number): A {
-    return (this.source as Behavior<A>).last;
+    return __UNSAFE_GET_LAST_BEHAVIOR_VALUE(this.source as Behavior<A>);
   }
   activate(t: number): void {
     if (this.source !== undefined) {
@@ -84,7 +89,7 @@ class MapPlaceholder<A, B> extends MapBehavior<A, B> {
 }
 
 class MapToPlaceholder<A, B> extends MapToStream<A, B> {
-  changedAt: Time;
+  changedAt?: Time;
   constructor(parent: Stream<A>, public last: B) {
     super(parent, last);
   }

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -10,9 +10,9 @@ import { Stream, MapToStream } from "./stream";
 import { tick } from "./clock";
 import { Future } from "./future";
 
-class SamplePlaceholderError {
+class SamplePlaceholderError<A> {
   message = "Attempt to sample non-replaced placeholder";
-  constructor(public placeholder: Placeholder<unknown>) {}
+  constructor(public placeholder: Placeholder<A>) {}
   toString(): string {
     return this.message;
   }

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -73,7 +73,7 @@ export class Placeholder<A> extends Behavior<A> {
 }
 
 export function isPlaceholder<A>(p: unknown): p is Placeholder<A> {
-  return typeof p === "object" && "replaceWith" in p;
+  return typeof p === "object" && p !== null && "replaceWith" in p;
 }
 
 class MapPlaceholder<A, B> extends MapBehavior<A, B> {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -44,7 +44,9 @@ export abstract class Stream<A> extends Reactive<A, SListener<A>>
     return scan(fn, startingValue, this);
   }
   scanFrom<B>(fn: (a: A, b: B) => B, startingValue: B): Behavior<Stream<B>> {
-    return fromFunction((t) => new ScanStream(fn, startingValue, this, t));
+    return fromFunction<Stream<B>>(
+      (t) => new ScanStream(fn, startingValue, this, t)
+    );
   }
   accum<B>(fn: (a: A, b: B) => B, init: B): Now<Behavior<B>> {
     return accum(fn, init, this);
@@ -309,7 +311,7 @@ export function changes<A>(
 export class CombineStream<A, B> extends Stream<A | B> {
   constructor(readonly s1: Stream<A>, readonly s2: Stream<B>) {
     super();
-    this.parents = cons<Stream<A | B>>(s1, cons(s2));
+    this.parents = cons<Stream<A> | Stream<B>>(s1, cons(s2));
   }
   pushS(t: number, a: A | B): void {
     this.pushSToChildren(t, a);
@@ -387,9 +389,9 @@ export function subscribe<A>(fn: (a: A) => void, stream: Stream<A>): void {
   stream.subscribe(fn);
 }
 
-export class SnapshotStream<B> extends Stream<B> {
+export class SnapshotStream<B, _> extends Stream<B> {
   private node: Node<this> = new Node(this);
-  constructor(readonly target: Behavior<B>, readonly trigger: Stream<unknown>) {
+  constructor(readonly target: Behavior<B>, readonly trigger: Stream<_>) {
     super();
     this.parents = cons(trigger);
   }
@@ -405,9 +407,9 @@ export class SnapshotStream<B> extends Stream<B> {
   }
 }
 
-export function snapshot<B>(
+export function snapshot<B, _>(
   target: Behavior<B>,
-  trigger: Stream<unknown>
+  trigger: Stream<_>
 ): Stream<B> {
   return new SnapshotStream(target, trigger);
 }
@@ -458,7 +460,7 @@ export function selfie<A>(stream: Stream<Behavior<A>>): Stream<A> {
   return new SelfieStream(stream);
 }
 
-export function isStream(s: unknown): s is Stream<unknown> {
+export function isStream<A>(s: unknown): s is Stream<A> {
   return typeof s === "object" && s !== null && "scanFrom" in s;
 }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -448,7 +448,7 @@ export function selfie<A>(stream: Stream<Behavior<A>>): Stream<A> {
 }
 
 export function isStream(s: unknown): s is Stream<unknown> {
-  return typeof s === "object" && "scanFrom" in s;
+  return typeof s === "object" && s !== null && "scanFrom" in s;
 }
 
 class PerformCbStream<A, B> extends ActiveStream<B> implements SListener<A> {
@@ -509,11 +509,12 @@ export class FlatFuturesOrdered<A> extends Stream<A> {
     });
   }
   pushFromBuffer(): void {
-    while (this.buffer[0] !== undefined) {
+    let a = this.buffer.shift();
+    while (a !== undefined) {
       const t = tick();
-      const { value } = this.buffer.shift();
-      this.pushSToChildren(t, value);
+      this.pushSToChildren(t, a.value);
       this.next++;
+      a = this.buffer.shift();
     }
   }
 }

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -221,7 +221,7 @@ CombineStream.prototype.model = function<A, B>(this: CombineStream<A, B>) {
   return result;
 };
 
-SnapshotStream.prototype.model = function<B>(this: SnapshotStream<B>) {
+SnapshotStream.prototype.model = function<B, _>(this: SnapshotStream<B, _>) {
   return this.trigger
     .model()
     .map(({ time }) => occurrence(time, testAt(time, this.target)));
@@ -305,16 +305,14 @@ export function testStreamFromObject<A>(object: Record<string, A>): Stream<A> {
 export function assertStreamEqual<A>(s1: Stream<A>, s2: Stream<A>): void;
 export function assertStreamEqual<A>(
   s1: Stream<A>,
-  s2: {
-    [time: number]: A;
-  }
+  s2: Record<number, A>
 ): void;
 export function assertStreamEqual<A>(s1: Stream<A>, s2: ([Time, A])[]): void;
 export function assertStreamEqual<A>(
   s1: Stream<A>,
-  s2: Stream<A> | ([Time, A])[]
+  s2: Stream<A> | ([Time, A])[] | Record<number, A>
 ): void {
-  const s2_ = isStream(s2)
+  const s2_ = isStream<A>(s2)
     ? s2
     : Array.isArray(s2)
     ? testStreamFromArray(s2)

--- a/src/time.ts
+++ b/src/time.ts
@@ -1,7 +1,10 @@
-import { Time, State } from "./common";
+import { Time, State, __UNSAFE_GET_LAST_BEHAVIOR_VALUE } from "./common";
 import { cons } from "./datastructures";
 import { Stream } from "./stream";
-import { Behavior, fromFunction } from "./behavior";
+import {
+  Behavior,
+  fromFunction
+} from "./behavior";
 import { sample, Now, perform } from "./now";
 
 /*
@@ -83,19 +86,20 @@ export const measureTime = sample(measureTimeFrom);
 
 class IntegrateBehavior extends Behavior<number> {
   private lastPullTime: Time;
+  last = 0;
+  state = State.Pull;
   constructor(private parent: Behavior<number>, t: number) {
     super();
     this.lastPullTime = time.at(t);
-    this.state = State.Pull;
-    this.last = 0;
     this.pulledAt = t;
     this.changedAt = t;
     this.parents = cons(parent, cons(time));
   }
   update(_t: Time): number {
-    const currentPullTime = time.last;
+    const currentPullTime = __UNSAFE_GET_LAST_BEHAVIOR_VALUE(time);
     const deltaMs = currentPullTime - this.lastPullTime;
-    const value = this.last + deltaMs * this.parent.last;
+    const value =
+      this.last + deltaMs * __UNSAFE_GET_LAST_BEHAVIOR_VALUE(this.parent);
     this.lastPullTime = currentPullTime;
     return value;
   }

--- a/src/time.ts
+++ b/src/time.ts
@@ -51,7 +51,9 @@ class DebounceStream<A> extends Stream<A> {
   }
   private timer: NodeJS.Timeout | undefined = undefined;
   pushS(t: number, a: A): void {
-    clearTimeout(this.timer);
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+    }
     this.timer = setTimeout(() => {
       this.pushSToChildren(t, a);
     }, this.ms);

--- a/src/time.ts
+++ b/src/time.ts
@@ -123,5 +123,5 @@ export function integrate(behavior: Behavior<number>): Now<Behavior<number>> {
 export function integrateFrom(
   behavior: Behavior<number>
 ): Behavior<Behavior<number>> {
-  return fromFunction((t) => new IntegrateBehavior(behavior, t));
+  return fromFunction<Behavior<number>>((t) => new IntegrateBehavior(behavior, t));
 }

--- a/test/future.ts
+++ b/test/future.ts
@@ -30,7 +30,7 @@ describe("Future", () => {
   });
   describe("sink", () => {
     it("notifies subscriber", () => {
-      let result: number;
+      let result: number | undefined;
       const s = sinkFuture<number>();
       s.subscribe((x: number) => {
         result = x;
@@ -40,7 +40,7 @@ describe("Future", () => {
       assert.strictEqual(result, 2);
     });
     it("notifies subscriber several layers down", () => {
-      let result: number;
+      let result: number | undefined;
       const s = sinkFuture<number>();
       const s2 = s.map((n) => n + 2).mapTo(9);
       s2.subscribe((x: number) => {
@@ -61,7 +61,7 @@ describe("Future", () => {
   });
   describe("Semigroup", () => {
     it("returns the first future if it occurs first", () => {
-      let result: number;
+      let result: number | undefined;
       const future1 = sinkFuture<number>();
       const future2 = sinkFuture<number>();
       const combined = future1.combine(future2);
@@ -71,7 +71,7 @@ describe("Future", () => {
       assert.strictEqual(result, 1);
     });
     it("returns the seconds future if it occurs first", () => {
-      let result: number;
+      let result: number | undefined;
       const future1 = sinkFuture<number>();
       const future2 = sinkFuture<number>();
       const combined = future1.combine(future2);
@@ -81,8 +81,8 @@ describe("Future", () => {
       assert.strictEqual(result, 2);
     });
     it("returns when only one occurs", () => {
-      let result1: number;
-      let result2: number;
+      let result1: number | undefined;
+      let result2: number | undefined;
       const future1 = sinkFuture<number>();
       const future2 = sinkFuture<number>();
       const combined = future1.combine(future2);
@@ -106,7 +106,7 @@ describe("Future", () => {
   });
   describe("Functor", () => {
     it("maps over value", () => {
-      let result: number;
+      let result: number | undefined;
       const s = sinkFuture<number>();
       const mapped = s.map((x) => x * x);
       mapped.subscribe((x: number) => {
@@ -117,7 +117,7 @@ describe("Future", () => {
       assert.strictEqual(result, 16);
     });
     it("maps to constant", () => {
-      let result: string;
+      let result: string | undefined;
       const s = sinkFuture<number>();
       const mapped = s.mapTo("horse");
       mapped.subscribe((x: string) => {
@@ -130,7 +130,7 @@ describe("Future", () => {
   });
   describe("Apply", () => {
     it("lifts a function of one argument", () => {
-      let result: string;
+      let result: string | undefined;
       const fut = sinkFuture<string>();
       const lifted = H.lift((s: string) => s + "!", fut);
       lifted.subscribe((s: string) => (result = s));
@@ -139,7 +139,7 @@ describe("Future", () => {
       assert.strictEqual(result, "Hello!");
     });
     it("lifts a function of three arguments", () => {
-      let result: string;
+      let result: string | undefined;
       const fut1 = sinkFuture<string>();
       const fut2 = sinkFuture<string>();
       const fut3 = sinkFuture<string>();
@@ -163,7 +163,7 @@ describe("Future", () => {
   });
   describe("Applicative", () => {
     it("of gives future that has occurred", () => {
-      let result: number;
+      let result: number | undefined;
       const o = Future.of(12);
       o.subscribe((x) => (result = x));
       assert.strictEqual(result, 12);
@@ -203,19 +203,21 @@ describe("Future", () => {
     });
   });
   it("can convert Promise to Future", async () => {
-    let result: number;
-    let resolve: (n: number) => void;
+    let result: number | undefined;
+    let resolve: ((n: number) => void) | undefined;
     const promise = new Promise((res) => (resolve = res));
     const future = fromPromise(promise);
     future.subscribe((res: number) => (result = res));
     assert.strictEqual(result, undefined);
-    resolve(12);
+    if (resolve !== undefined) {
+      resolve(12);
+    }
     await promise;
     assert.strictEqual(result, 12);
   });
   describe("nextOccurence", () => {
     it("resolves on next occurence", () => {
-      let result: string;
+      let result: string | undefined;
       const s = new SinkStream<string>();
       const next = nextOccurrenceFrom(s);
       s.push("a");
@@ -230,8 +232,8 @@ describe("Future", () => {
     it("resolves with result when done callback invoked", () => {
       const fut = sinkFuture<number>();
       const cb = spy();
-      let value: number;
-      let done: (result: unknown) => void;
+      let value: number | undefined;
+      let done: ((result: unknown) => void) | undefined;
       const fut2 = mapCbFuture((v, d) => {
         value = v;
         done = d;
@@ -240,7 +242,9 @@ describe("Future", () => {
       fut.resolve(3);
       assert.equal(value, 3);
       assert.equal(cb.callCount, 0);
-      done(value + 1);
+      if (done !== undefined && value !== undefined) {
+        done(value + 1);
+      }
       assert.equal(cb.callCount, 1);
       assert.deepEqual(cb.args, [[4]]);
     });

--- a/test/now.ts
+++ b/test/now.ts
@@ -157,7 +157,9 @@ describe("Now", () => {
     function loop(n: number): Now<Behavior<number>> {
       return go(function*() {
         const nextNumber: Future<number> = yield performIO(getNextNr(1));
-        const future = yield plan(nextNumber.map(loop));
+        const future: Future<Behavior<number>> = yield plan(
+          nextNumber.map(loop)
+        );
         return switchTo(Behavior.of(n), future);
       });
     }
@@ -235,22 +237,24 @@ describe("Now", () => {
   describe("loopNow", () => {
     it("should loop the reactives", () => {
       const result: unknown[] = [];
-      let s: SinkStream<string>;
+      let s: SinkStream<string> | undefined;
       const now = loopNow(({ stream }) => {
         stream.subscribe((a) => result.push(a));
         s = sinkStream();
         return Now.of({ stream: s });
       });
       runNow(now);
-      s.push("a");
-      s.push("b");
-      s.push("c");
+      if (s !== undefined) {
+        s.push("a");
+        s.push("b");
+        s.push("c");
+      }
 
       assert.deepEqual(result, ["a", "b", "c"]);
     });
     it("should return the reactives", () => {
       const result: unknown[] = [];
-      let s: SinkStream<string>;
+      let s: SinkStream<string> | undefined;
       const now = loopNow(({ stream }) => {
         stream.subscribe((a) => a);
         s = sinkStream();
@@ -258,9 +262,11 @@ describe("Now", () => {
       });
       const { stream } = runNow(now);
       stream.subscribe((a) => result.push(a));
-      s.push("a");
-      s.push("b");
-      s.push("c");
+      if (s !== undefined) {
+        s.push("a");
+        s.push("b");
+        s.push("c");
+      }
       assert.deepEqual(result, ["a", "b", "c"]);
     });
   });

--- a/test/placeholder.ts
+++ b/test/placeholder.ts
@@ -24,7 +24,7 @@ import { createTestProducerBehavior } from "./helpers";
 describe("placeholder", () => {
   describe("behavior", () => {
     it("subscribers are notified when placeholder is replaced", () => {
-      let result: number;
+      let result: number | undefined;
       const p = placeholder<string>();
       const mapped = p.map((s) => s.length);
       mapped.subscribe((n: number) => (result = n));
@@ -32,7 +32,7 @@ describe("placeholder", () => {
       assert.strictEqual(result, 5);
     });
     it("subscribers are notified when placeholder is replaced 2", () => {
-      let result: string;
+      let result: string | undefined;
       const p = placeholder<string>();
       p.subscribe((s) => (result = s));
       p.replaceWith(Behavior.of("Hello"));
@@ -86,7 +86,7 @@ describe("placeholder", () => {
       const mapResult: unknown[] = [];
       const pm = p.map((n) => (mapResult.push(n), n));
       const result: Array<number> = [];
-      let pull: (t?: number) => void;
+      let pull: ((t?: number) => void) | undefined;
       observe(
         (a) => {
           result.push(a);
@@ -100,11 +100,13 @@ describe("placeholder", () => {
         pm
       );
       p.replaceWith(b);
-      pull();
-      variable = 1;
-      pull();
-      variable = 2;
-      pull();
+      if (pull !== undefined) {
+        pull();
+        variable = 1;
+        pull();
+        variable = 2;
+        pull();
+      }
       assert.deepEqual(result, [0, 1, 2], "result");
       assert.deepEqual(mapResult, [0, 1, 2], "mapResult");
     });
@@ -192,7 +194,7 @@ describe("placeholder", () => {
       const change = sum.map((_) => 1);
       const sum2 = H.at(H.switcherFrom(H.at(H.integrateFrom(change)), H.empty));
       const results: unknown[] = [];
-      let pull: () => void;
+      let pull: (() => void) | undefined;
       observe(
         (n: number) => results.push(n),
         (p) => {
@@ -202,11 +204,13 @@ describe("placeholder", () => {
         sum
       );
       sum.replaceWith(sum2);
-      pull();
-      setTime(4000);
-      pull();
-      setTime(7000);
-      pull();
+      if (pull !== undefined) {
+        pull();
+        setTime(4000);
+        pull();
+        setTime(7000);
+        pull();
+      }
       assert.deepEqual(results, [0, 2000, 5000]);
       restore();
     });
@@ -373,14 +377,14 @@ describe("placeholder", () => {
       assert.isTrue(H.isFuture(placeholder()));
     });
     it("subscribers are notified when replaced with occurred future", () => {
-      let result: string;
+      let result: string | undefined;
       const p = placeholder<string>();
       p.subscribe((n: string) => (result = n));
       p.replaceWith(H.Future.of("Hello"));
       assert.strictEqual(result, "Hello");
     });
     it("subscribers are notified when placeholder has been replaced", () => {
-      let result: string;
+      let result: string | undefined;
       const p = placeholder<string>();
       p.replaceWith(H.Future.of("Hello"));
       p.subscribe((n: string) => (result = n));

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -89,7 +89,7 @@ describe("stream", () => {
     });
     it("pushes to listener", () => {
       const callback = spy();
-      let push: (t: number, n: number) => void;
+      let push: ((t: number, n: number) => void) | undefined;
       class MyProducer<A> extends H.ProducerStream<A> {
         activate(): void {
           push = this.pushS.bind(this);
@@ -100,8 +100,10 @@ describe("stream", () => {
       }
       const producer = new MyProducer();
       producer.subscribe(callback);
-      push(1, 1);
-      push(2, 2);
+      if (push !== undefined) {
+        push(1, 1);
+        push(2, 2);
+      }
       assert.deepEqual(callback.args, [[1], [2]]);
     });
   });
@@ -120,14 +122,16 @@ describe("stream", () => {
     });
     it("pushes to listener", () => {
       const callback = spy();
-      let push: (n: number) => void;
+      let push: ((n: number) => void) | undefined;
       const producer = H.producerStream((p) => {
         push = p;
         return () => (push = undefined);
       });
       producer.subscribe(callback);
-      push(1);
-      push(2);
+      if (push !== undefined) {
+        push(1);
+        push(2);
+      }
       assert.deepEqual(callback.args, [[1], [2]]);
     });
   });

--- a/test/time.ts
+++ b/test/time.ts
@@ -77,7 +77,7 @@ describe("behavior", () => {
         const [setTime, restore] = mockNow();
         setTime(3);
         const time = H.runNow(H.measureTime);
-        let pull: (t?: number) => void;
+        let pull: ((t?: number) => void) | undefined;
         const results: number[] = [];
         H.observe(
           (n: number) => {
@@ -89,11 +89,13 @@ describe("behavior", () => {
           },
           time
         );
-        pull();
-        setTime(4);
-        pull();
-        setTime(7);
-        pull();
+        if (pull !== undefined) {
+          pull();
+          setTime(4);
+          pull();
+          setTime(7);
+          pull();
+        }
         assert.deepEqual(results, [0, 1, 4]);
         restore();
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "importHelpers": true,
     "sourceMap": true,
     "skipLibCheck": true,
-    "lib": ["dom", "es5", "es2015", "es2019"]
+    "lib": ["dom", "es5", "es2015", "es2019"],
+    "strictNullChecks": true
   },
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
     "skipLibCheck": true,
     "lib": ["dom", "es5", "es2015", "es2019"],
     "strictNullChecks": true,
-    "strictPropertyInitialization": true
+    "strictPropertyInitialization": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true
   },
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "sourceMap": true,
     "skipLibCheck": true,
     "lib": ["dom", "es5", "es2015", "es2019"],
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true
   },
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Hi, this is a continuation of #78 (means #78 should be merged first) and contains changes after enabling TS `strictBindCallApply` and `strictFunctionTypes` flags.

```
BREAKING CHANGE: pushToChildren requires type argument
BREAKING CHANGE: whenFrom returns Behavior<Future<boolean>> instead of Behavior<Future<{}>>
BREAKING CHANGE: when returns Now<Future<boolean>> instead of Now<Future<{}>>
BREAKING CHANGE: toggleFrom/toggle require type arguments
BREAKING CHANGE: MapToFuture requires additional type argument
BREAKING CHANGE: snapshot/SnapshotStream/isStream require additional type argument
BREAKING CHANGE: SnapshotStream.prototype.model requires additional type argument
```