### PR TITLE
Fix testing Future combine

### DIFF
--- a/src/testing.ts
+++ b/src/testing.ts
@@ -74,7 +74,7 @@ export function doesOccur<A>(
 CombineFuture.prototype.model = function() {
   const a = this.parentA.model();
   const b = this.parentB.model();
-  return a.time <= b.time ? a : b;
+  return doesOccur(a) && (!doesOccur(b) || a.time <= b.time) ? a : b;
 };
 
 MapFuture.prototype.model = function() {

--- a/test/testing.ts
+++ b/test/testing.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import * as H from "../src";
-import { Behavior, Stream, Now } from "../src";
+import { Behavior, Stream, never, Now } from "../src";
 import {
   testFuture,
   assertFutureEqual,
@@ -43,6 +43,20 @@ describe("testing", () => {
         const fut2 = testFuture(3, "bar");
         const res = H.combine(fut1, fut2);
         assertFutureEqual(res, fut2);
+      });
+      it("gives first future if only resolved", () => {
+        const fut1 = testFuture(4, "foo");
+        const res = H.combine(fut1, never);
+        assertFutureEqual(res, fut1);
+      });
+      it("gives second future if only resolved", () => {
+        const fut2 = testFuture(3, "bar");
+        const res = H.combine(never, fut2);
+        assertFutureEqual(res, fut2);
+      });
+      it("gives never if none resolved", () => {
+        const res = H.combine(never, never);
+        assertFutureEqual(res, never);
       });
     });
     describe("functor", () => {


### PR DESCRIPTION
Testing combine for Futures did not behave correctly when the second future does not occur. This request adds respective test cases and fixes the bug.