### PR TITLE
Add EditorConfig and ignore .DS_Store

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test/**/*.js
 yarn.lock
 .idea
 output
+.DS_Store


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org/) is an IDE independent way to configure basic file formatting properties. I use it to ensure my IDE (IntelliJ) adheres to the present standard of the project. I propose adding it for dev convenience as well as ignoring .DS_Store files. 