### PR TITLE
Fix issue with isBehavior return true for arrays

### DIFF
--- a/src/behavior.ts
+++ b/src/behavior.ts
@@ -139,7 +139,7 @@ function refresh<A>(b: Behavior<A>, t: number) {
 
 export function isBehavior<A>(b: unknown): b is Behavior<A> {
   return (
-    (typeof b === "object" && "at" in b && !isPlaceholder(b)) ||
+    (typeof b === "object" && "at" in b && "pull" in b && !isPlaceholder(b)) ||
     (isPlaceholder(b) && (b.source === undefined || isBehavior(b.source)))
   );
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -5,7 +5,7 @@ import { tick } from "./clock";
 export type Time = number;
 
 function isBehavior(b: unknown): b is Behavior<unknown> {
-  return typeof b === "object" && "at" in b;
+  return typeof b === "object" && "at" in b && "pull" in b;
 }
 
 export type PullHandler = (pull: (t?: number) => void) => () => void;


### PR DESCRIPTION
# Purpose
Browsers are introducing an `at` function on arrays, which makes the `isBehavior` function return true for arrays.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at

# Changes
- `isBehavior` now also checks for a "pull" property.